### PR TITLE
[12.0][FIX] storage_image dependencies

### DIFF
--- a/storage_image/__manifest__.py
+++ b/storage_image/__manifest__.py
@@ -13,7 +13,6 @@
     "development_status": "Stable/Production",
     "installable": True,
     "depends": ["storage_thumbnail"],
-    "external_dependencies": {"python": ["requests_mock"]},
     "data": [
         "views/storage_image_view.xml",
         "views/js.xml",


### PR DESCRIPTION
Remove requests_mock dependency in manifest.
It's a test dependency, it should not block the installation of the module.