### PR TITLE
[12.0][IMP] storage_backend_s3 - add compatibility with OVH's Openstack

### DIFF
--- a/storage_backend_s3/components/s3_adapter.py
+++ b/storage_backend_s3/components/s3_adapter.py
@@ -33,6 +33,8 @@ class S3StorageAdapter(Component):
         }
         if self.collection.aws_host:
             params["endpoint_url"] = self.collection.aws_host
+        if not params["region_name"]:
+            # For some providers,
             # region must be excluded, otherwise endpoint is ignored
             params.pop("region_name", None)
         return params

--- a/storage_backend_s3/views/backend_storage_view.xml
+++ b/storage_backend_s3/views/backend_storage_view.xml
@@ -9,6 +9,7 @@
                 <field name="aws_host" />
                 <field name="aws_access_key_id" attrs="{'required': [('backend_type', '=', 'amazon_s3')]}"/>
                 <field name="aws_secret_access_key" attrs="{'required': [('backend_type', '=', 'amazon_s3')], 'readonly':[('backend_type', '!=', 'amazon_s3')]}"/>
+                <field name="aws_available_regions" />
                 <field name="aws_region" attrs="{'required': [('backend_type', '=', 'amazon_s3'),('aws_host','=',False)]}"/>
                 <field name="aws_bucket"  attrs="{'required': [('backend_type', '=', 'amazon_s3')]}"/>
                 <field name="aws_cache_control"/>


### PR DESCRIPTION
Add support of regions other than ones from AWS (manually entered by the user).

In the case of Openstack / OVH , region and enpoint (host) should be used.
@sebastienbeau do you know in which case region should be removed ?
