### PR TITLE
[13.0] storage_file: fix error creating a new file

### DIFF
--- a/storage_file/models/storage_file.py
+++ b/storage_file/models/storage_file.py
@@ -154,7 +154,7 @@ class StorageFile(models.Model):
             parts = [backend.base_url or ""]
             if backend.url_include_directory_path and backend.directory_path:
                 parts.append(backend.directory_path)
-            parts.append(self.relative_path)
+            parts.append(self.relative_path or "")
         return "/".join(parts)
 
     @api.depends("name")


### PR DESCRIPTION
This patch fixes an error when a new file is created using the backend ui.

It is very simple and self explanatory.

It is the same as: GH-44 but for 13.0