### PR TITLE
[13.0][ADD] Image handle widget

### DIFF
--- a/storage_image/models/__init__.py
+++ b/storage_image/models/__init__.py
@@ -1,2 +1,3 @@
 from . import storage_image
 from . import storage_file
+from . import storage_relation_abstract

--- a/storage_image/models/storage_relation_abstract.py
+++ b/storage_image/models/storage_relation_abstract.py
@@ -1,0 +1,23 @@
+# Copyright 2020 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ImageRelationAbstract(models.AbstractModel):
+    """ Use this abstract if you want to add a relation between a model and
+    storage.image ImageRelationAbstract comes with a JS widget 'image_handle'.
+    Use this widget on your field in kanaban mode if you want to enable images adding
+    and vignettes sequencing by drag&drop.
+    """
+
+    _name = "image.relation.abstract"
+    _description = "Image Relation Abstract"
+    _order = "sequence, image_id"
+
+    sequence = fields.Integer()
+    image_id = fields.Many2one("storage.image", required=True)
+    # for kanban view
+    image_name = fields.Char(related="image_id.name")
+    # for kanban view
+    image_url = fields.Char(related="image_id.image_medium_url")

--- a/storage_image/readme/CONTRIBUTORS.rst
+++ b/storage_image/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Antiun Ingeniería S.L. - Jairo Llopis
 * Denis Roussel <denis.roussel@acsone.eu>
+* Quentin Groulard <quentin.groulard@acsone.eu>

--- a/storage_image/static/src/css/image_handle.css
+++ b/storage_image/static/src/css/image_handle.css
@@ -1,0 +1,4 @@
+.is-dragover {
+    outline: 2px dashed #4f94c9;
+    outline-offset: +2px;
+}

--- a/storage_image/static/src/js/image_handle.js
+++ b/storage_image/static/src/js/image_handle.js
@@ -1,0 +1,75 @@
+odoo.define("storage_image.image_handle", function(require) {
+    "use strict";
+    var registry = require("web.field_registry");
+    var relational_fields = require("web.relational_fields");
+
+    var FieldImageHandle = relational_fields.FieldOne2Many.extend({
+        _render: function() {
+            var self = this;
+            if (!this.isReadonly && this.activeActions.create) {
+                this.$el.on("dragover dragenter", function(e) {
+                    self.$el.addClass("is-dragover");
+                    e.preventDefault();
+                    e.stopPropagation();
+                });
+                this.$el.on("dragleave dragend drop", function(e) {
+                    self.$el.removeClass("is-dragover");
+                    e.preventDefault();
+                    e.stopPropagation();
+                });
+                this.$el.on("drop", function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    self.upload_images(e.originalEvent.dataTransfer.files);
+                });
+            }
+            return this._super();
+        },
+
+        upload_images: function(files) {
+            var self = this;
+            var promises = [];
+            _.each(files, function(file) {
+                if (!file.type.includes("image")) {
+                    return;
+                }
+                var filePromise = new Promise(function(resolve) {
+                    var reader = new FileReader();
+                    reader.readAsDataURL(file);
+                    reader.onload = function(upload) {
+                        var data = upload.target.result;
+                        data = data.split(",")[1];
+                        resolve([file.name, data]);
+                    };
+                });
+                promises.push(filePromise);
+            });
+            Promise.all(promises).then(function(fileContents) {
+                var args = [];
+                _.each(fileContents, function(content) {
+                    args.push({name: content[0], image_medium_url: content[1]});
+                });
+                self._rpc({
+                    model: "storage.image",
+                    method: "create",
+                    args: [args],
+                }).then(function(images) {
+                    var context = [];
+                    _.each(images, function(image) {
+                        var context_val = {};
+                        var default_image_field = "default_image_id";
+                        context_val[default_image_field] = image;
+                        context.push(context_val);
+                    });
+                    self.trigger_up("add_record", {
+                        forceEditable: "bottom",
+                        allowWarning: true,
+                        context: context,
+                    });
+                });
+            });
+        },
+    });
+    registry.add("image_handle", FieldImageHandle);
+    return FieldImageHandle;
+});

--- a/storage_image/views/js.xml
+++ b/storage_image/views/js.xml
@@ -8,9 +8,18 @@
         inherit_id="web.assets_backend"
     >
         <xpath expr="." position="inside">
+            <link
+                rel="stylesheet"
+                type="text/css"
+                href="/storage_image/static/src/css/image_handle.css"
+            />
             <script
                 type="text/javascript"
                 src="/storage_image/static/src/js/storage_image.js"
+            />
+            <script
+                type="text/javascript"
+                src="/storage_image/static/src/js/image_handle.js"
             />
         </xpath>
     </template>

--- a/storage_image_product/models/category_image_relation.py
+++ b/storage_image_product/models/category_image_relation.py
@@ -12,16 +12,11 @@ _logger = logging.getLogger(__name__)
 
 class CategoryImageRelation(models.Model):
     _name = "category.image.relation"
+    _inherit = "image.relation.abstract"
     _description = "Category Image Relation"
 
-    image_id = fields.Many2one("storage.image", required=True)
     category_id = fields.Many2one("product.category")
     tag_id = fields.Many2one("image.tag", domain=[("apply_on", "=", "category")])
-
-    # for kanban view
-    image_name = fields.Char(related="image_id.name")
-    # for kanban view
-    image_url = fields.Char(related="image_id.image_medium_url")
 
 
 class ImageTag(models.Model):

--- a/storage_image_product/models/product_image_relation.py
+++ b/storage_image_product/models/product_image_relation.py
@@ -12,11 +12,9 @@ _logger = logging.getLogger(__name__)
 
 class ProductImageRelation(models.Model):
     _name = "product.image.relation"
+    _inherit = "image.relation.abstract"
     _description = "Product Image Relation"
-    _order = "sequence, image_id"
 
-    sequence = fields.Integer()
-    image_id = fields.Many2one("storage.image", required=True)
     attribute_value_ids = fields.Many2many(
         "product.attribute.value", string="Attributes"
     )
@@ -28,11 +26,6 @@ class ProductImageRelation(models.Model):
         compute="_compute_available_attribute",
     )
     product_tmpl_id = fields.Many2one("product.template")
-    # for kanban view
-    image_name = fields.Char(related="image_id.name")
-    # for kanban view
-    image_url = fields.Char(related="image_id.image_medium_url")
-
     tag_id = fields.Many2one("image.tag", domain=[("apply_on", "=", "product")])
 
     @api.depends("image_id", "product_tmpl_id.attribute_line_ids.value_ids")

--- a/storage_image_product/readme/CONTRIBUTORS.rst
+++ b/storage_image_product/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Denis Roussel <denis.roussel@acsone.eu>
+* Quentin Groulard <quentin.groulard@acsone.eu>

--- a/storage_image_product/views/product_category.xml
+++ b/storage_image_product/views/product_category.xml
@@ -6,7 +6,7 @@
         <field name="arch" type="xml">
             <xpath expr="//group[last()]" position="after">
                 <group name="images" string="Images">
-                    <field name="image_ids" mode="kanban" />
+                    <field name="image_ids" mode="kanban" widget="image_handle" />
                 </group>
             </xpath>
         </field>
@@ -31,6 +31,7 @@
             <kanban>
                 <field name="image_name" />
                 <field name="image_url" />
+                <field name="image_id" invisible="1" />
                 <templates>
                     <t t-name="kanban-box">
                         <div class="oe_kanban_vignette oe_semantic_html_override">

--- a/storage_image_product/views/product_image_relation.xml
+++ b/storage_image_product/views/product_image_relation.xml
@@ -33,6 +33,8 @@
                 <field name="image_name" />
                 <field name="image_url" />
                 <field name="attribute_value_ids" />
+                <field name="sequence" widget="handle" />
+                <field name="image_id" invisible="1" />
                 <templates>
                     <t t-name="kanban-box">
                         <div class="oe_kanban_vignette oe_semantic_html_override">

--- a/storage_image_product/views/product_product.xml
+++ b/storage_image_product/views/product_product.xml
@@ -37,7 +37,11 @@
                     <p
                         class="oe_grey"
                     >If you need to edit the images, do it from the product template.</p>
-                    <field name="variant_image_ids" mode="kanban" />
+                    <field
+                        name="variant_image_ids"
+                        mode="kanban"
+                        widget="image_handle"
+                    />
                 </page>
             </xpath>
         </field>

--- a/storage_image_product/views/product_template.xml
+++ b/storage_image_product/views/product_template.xml
@@ -11,7 +11,7 @@
             </field>
             <xpath expr="//page[@name='sales']" position="after">
                 <page name="image" string="Image">
-                    <field name="image_ids" mode="kanban" />
+                    <field name="image_ids" mode="kanban" widget="image_handle" />
                 </page>
             </xpath>
         </field>


### PR DESCRIPTION
Forward port of https://github.com/OCA/storage/pull/48

Without the drag&drop reordering part since it's now supported by Odoo. (https://github.com/odoo/odoo/pull/28581/commits/2c28ffe258fa470e79f3eb786f0cb76eb8f20dcd)
We combine this widget with the widget 'handle' on the sequence field to achieve the same result as in https://github.com/OCA/storage/pull/48.