### PR TITLE
[10.0][IMP] Improve storage_image widget during sequence update

### DIFF
--- a/storage_image/README.rst
+++ b/storage_image/README.rst
@@ -36,6 +36,7 @@ Contributors
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Antiun Ingeniería S.L. - Jairo Llopis
+* Quentin Groulard <quentin.groulard@acsone.eu>
 
 Maintainer
 ----------

--- a/storage_image/__init__.py
+++ b/storage_image/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import models
+from . import controllers

--- a/storage_image/__manifest__.py
+++ b/storage_image/__manifest__.py
@@ -13,7 +13,7 @@
     "license": "AGPL-3",
     "installable": True,
     "external_dependencies": {"python": [], "bin": []},
-    "depends": ["storage_thumbnail"],
+    "depends": ["storage_thumbnail", "web_kanban"],
     "data": [
         "views/storage_image_view.xml",
         "views/js.xml",

--- a/storage_image/controllers/__init__.py
+++ b/storage_image/controllers/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import data_set

--- a/storage_image/controllers/data_set.py
+++ b/storage_image/controllers/data_set.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import http
+from odoo.http import request
+
+
+class DataSetController(http.Controller):
+    @http.route("/web/dataset/resequence_child", type="json", auth="user")
+    def resequence_child(
+        self, model, target_id, child_field, children_ids, field="sequence", offset=0
+    ):
+        """
+        Based on 'resequence' function on the DataSet Odoo controller.
+        The purpose is to resequence children recordset but on the parent's
+        model.
+        That's useful when there is a related field or a computed fields
+        (with depends) where the update is triggered only if we have a write
+        on the parent's record.
+        :param model: str
+        :param target_id: int
+        :param child_field: str
+        :param children_ids: list of int
+        :param field: str
+        :param offset: int
+        :return: bool
+        """
+        target_model = request.env[model]
+        # Ensure the child field exists on the parent.
+        if not target_model.fields_get([child_field]):
+            return False
+        sub_target = target_model._fields.get(child_field).comodel_name
+        sub_target_model = request.env[sub_target]
+        # Ensure the (sequence) field exists on the child.
+        if not sub_target_model.fields_get([field]):
+            return False
+        all_values = []
+        # python 2.6 has no start parameter
+        for i, record in enumerate(sub_target_model.browse(children_ids)):
+            all_values.append((1, record.id, {field: i + offset}))
+        return target_model.browse(target_id).write({child_field: all_values})

--- a/storage_image/models/__init__.py
+++ b/storage_image/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import storage_image
 from . import storage_file
+from . import image_relation_abstract

--- a/storage_image/models/image_relation_abstract.py
+++ b/storage_image/models/image_relation_abstract.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ImageRelationAbstract(models.AbstractModel):
+    """ Use this abstract if you want to add a relation between a model and
+    storage.image ImageRelationAbstract comes with a JS widget 'image_handle'.
+    Use this widget on your field in kanaban mode if you want to enable images adding
+    and vignettes sequencing by drag&drop.
+    """
+
+    _name = "image.relation.abstract"
+    _description = "Image Relation Abstract"
+    _order = "sequence, image_id"
+
+    sequence = fields.Integer()
+    image_id = fields.Many2one("storage.image", required=True)
+    # for kanban view
+    image_name = fields.Char(related="image_id.name")
+    # for kanban view
+    image_url = fields.Char(related="image_id.image_medium_url")

--- a/storage_image/static/src/css/image_handle.css
+++ b/storage_image/static/src/css/image_handle.css
@@ -1,0 +1,4 @@
+.is-dragover {
+    outline: 2px dashed #4F94C9;
+    outline-offset: +2px;
+}

--- a/storage_image/static/src/js/image_handle.js
+++ b/storage_image/static/src/js/image_handle.js
@@ -1,0 +1,90 @@
+odoo.define('storage_image.image_handle', function (require) {
+    "use strict";
+    var core = require('web.core');
+    var data = require('web.data');
+    var Model = require("web.DataModel");
+    var kanban = require("web_kanban.KanbanView");
+    var m2m_kanban = require("web_kanban.Many2ManyKanbanView");
+
+    core.view_registry.get("one2many_kanban").include({
+        render: function () {
+            var res = this._super.apply(this, arguments);
+            var self = this;
+            if (!self.options["read_only_mode"]) {
+                if (self.options["creatable"]) {
+                    this.$el.css('min-height', '50px')
+                    this.$el.on('dragenter dragover', function (e) {
+                        self.$el.addClass('is-dragover');
+                        e.preventDefault();
+                        e.stopPropagation();
+                    });
+                    this.$el.on('dragleave dragend drop', function (e) {
+                        self.$el.removeClass('is-dragover');
+                        e.preventDefault();
+                        e.stopPropagation();
+                    });
+                    this.$el.on('drop', function (e) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        self.upload_images(e.originalEvent.dataTransfer.files);
+                    });
+                }
+                this.$el.sortable({
+                    tolerance: 'pointer',
+                    cursor: 'move',
+                    update: function () {
+                        new data.DataSet(self, self.record_options.model).resequence(self._getIDs())
+                    },
+                });
+            }
+            return res
+        },
+
+        upload_images: function (files) {
+            var self = this;
+            var promises = [];
+            _.each(files, function (file) {
+                if (!file.type.includes("image")) {
+                    return
+                }
+                var filePromise = new Promise(function (resolve) {
+                    var reader = new FileReader();
+                    reader.readAsDataURL(file);
+                    reader.onload = function (upload) {
+                        var data = upload.target.result;
+                        data = data.split(',')[1];
+                        resolve([file.name, data]);
+                    };
+                });
+                promises.push(filePromise);
+            });
+            Promise.all(promises).then(function (fileContents) {
+                var args = []
+                _.each(fileContents, function (content) {
+                    args.push({ 'name': content[0], 'image_medium_url': content[1] })
+                });
+                _.each(args, function (arg) {
+                    new Model("storage.image").call("create", [arg]).done(function (image) {
+                        self.x2m.node.attrs.context = {};
+                        self.x2m.node.attrs.context["default_image_id"] = image;
+                        self.add_record();
+                    });
+                });
+            });
+        },
+
+        /**
+         * @returns {integer[]} the virtual_ids of the records in the kanban view
+         */
+        _getIDs: function () {
+            var ids = [];
+            this.$el.find('.oe_kanban_vignette').each(function (index, r) {
+                var id = $(r).data('record').id;
+                if (Number.isInteger(id)) {
+                    ids.push(id);
+                }
+            });
+            return ids;
+        },
+    });
+});

--- a/storage_image/static/src/js/image_handle.js
+++ b/storage_image/static/src/js/image_handle.js
@@ -3,8 +3,30 @@ odoo.define('storage_image.image_handle', function (require) {
     var core = require('web.core');
     var data = require('web.data');
     var Model = require("web.DataModel");
+    var session = require('web.session');
+    var pyeval = require('web.pyeval');
     var kanban = require("web_kanban.KanbanView");
     var m2m_kanban = require("web_kanban.Many2ManyKanbanView");
+
+    data.DataSet.include({
+        /* Inherit the DataSet to include a resequence on the parent record */
+        init : function() {
+            this._super.apply(this, arguments);
+        },
+
+        resequence_child: function (id, child_field, children_ids, options) {
+            options = options || {};
+            return session.rpc('/web/dataset/resequence_child', {
+                model: this.model,
+                target_id: id,
+                child_field: child_field,
+                children_ids: children_ids,
+                context: pyeval.eval('context', this.get_context(options.context)),
+            }).then(function (results) {
+                return results;
+            });
+        },
+    });
 
     core.view_registry.get("one2many_kanban").include({
         render: function () {
@@ -33,7 +55,14 @@ odoo.define('storage_image.image_handle', function (require) {
                     tolerance: 'pointer',
                     cursor: 'move',
                     update: function () {
-                        new data.DataSet(self, self.record_options.model).resequence(self._getIDs())
+                        // Only if we have info related to the parent
+                        if (self.dataset && self.dataset.parent_view.model && self.dataset.parent_view.datarecord && self.dataset.child_name) {
+                            new data.DataSet(self, self.dataset.parent_view.model).resequence_child(self.dataset.parent_view.datarecord.id, self.dataset.child_name, self._getIDs());
+                        }
+                        else {
+                            // If not, call the resequence on the relation record
+                            new data.DataSet(self, self.record_options.model).resequence(self._getIDs());
+                        }
                     },
                 });
             }

--- a/storage_image/views/js.xml
+++ b/storage_image/views/js.xml
@@ -5,7 +5,9 @@
 
         <template id="assets_backend" name="storage_image assets" inherit_id="web.assets_backend">
             <xpath expr="." position="inside">
+                <link rel="stylesheet" type="text/css" href="/storage_image/static/src/css/image_handle.css"/>
                 <script type="text/javascript" src="/storage_image/static/src/js/storage_image.js"></script>
+                <script type="text/javascript" src="/storage_image/static/src/js/image_handle.js"></script>
             </xpath>
         </template>
 

--- a/storage_image_product/README.rst
+++ b/storage_image_product/README.rst
@@ -57,6 +57,7 @@ Contributors
 ------------
 
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
+* Quentin Groulard <quentin.groulard@acsone.eu>
 
 
 Maintainer

--- a/storage_image_product/models/category_image_relation.py
+++ b/storage_image_product/models/category_image_relation.py
@@ -13,16 +13,10 @@ _logger = logging.getLogger(__name__)
 
 class CategoryImageRelation(models.Model):
     _name = "category.image.relation"
+    _inherit = "image.relation.abstract"
 
-    sequence = fields.Integer()
-    image_id = fields.Many2one("storage.image", required=True)
     category_id = fields.Many2one("product.category")
     tag_id = fields.Many2one("image.tag", domain=[("apply_on", "=", "category")])
-
-    # for kanban view
-    image_name = fields.Char(related="image_id.name")
-    # for kanban view
-    image_url = fields.Char(related="image_id.image_medium_url")
 
 
 class ImageTag(models.Model):

--- a/storage_image_product/models/product_image_relation.py
+++ b/storage_image_product/models/product_image_relation.py
@@ -13,10 +13,8 @@ _logger = logging.getLogger(__name__)
 
 class ProductImageRelation(models.Model):
     _name = "product.image.relation"
-    _order = "sequence, image_id"
+    _inherit = "image.relation.abstract"
 
-    sequence = fields.Integer()
-    image_id = fields.Many2one("storage.image", required=True)
     attribute_value_ids = fields.Many2many(
         "product.attribute.value", string="Attributes"
     )
@@ -28,11 +26,6 @@ class ProductImageRelation(models.Model):
         compute="_compute_available_attribute",
     )
     product_tmpl_id = fields.Many2one("product.template")
-    # for kanban view
-    image_name = fields.Char(related="image_id.name")
-    # for kanban view
-    image_url = fields.Char(related="image_id.image_medium_url")
-
     tag_id = fields.Many2one("image.tag", domain=[("apply_on", "=", "product")])
 
     @api.depends("image_id", "product_tmpl_id.attribute_line_ids.value_ids")

--- a/storage_image_product/views/product_image_relation.xml
+++ b/storage_image_product/views/product_image_relation.xml
@@ -41,6 +41,7 @@
                 <field name="image_name"/>
                 <field name="image_url"/>
                 <field name="attribute_value_ids"/>
+                <field name="image_id" invisible="1"/>
                 <templates>
                     <t t-name="kanban-box">
                         <div class="oe_kanban_vignette oe_semantic_html_override">

--- a/storage_image_product/views/product_product.xml
+++ b/storage_image_product/views/product_product.xml
@@ -32,7 +32,7 @@
             <xpath expr="//page[@name='sales']" position="after">
                 <page name="image" string="Image">
                     <p class="oe_grey">If you need to edit the images, do it from the product template.</p>
-                    <field name="variant_image_ids" mode="kanban"/>
+                    <field name="variant_image_ids" mode="kanban" widget="image_handle"/>
                 </page>
             </xpath>
         </field>

--- a/storage_image_product/views/product_template.xml
+++ b/storage_image_product/views/product_template.xml
@@ -14,7 +14,7 @@
             </field>
             <xpath expr="//page[@name='sales']" position="after">
                 <page name="image" string="Image">
-                    <field name="image_ids" mode="tree" />
+                    <field name="image_ids" mode="kanban" widget="image_handle"/>
                 </page>
             </xpath>
         </field>


### PR DESCRIPTION
The widget works properly but in some case, the update of the sequence should be done on the parent record to ensure computed or related fields are correctly triggered.

For this case, the `image_medium_url` (on `product.template`) wasn't updated if we update the image order. Because the `write(...)` was done on the relation model.

Depends on https://github.com/OCA/storage/pull/56. Please review this PR first!

Changes compared to original PR:
- Add the `resequence_child` on JS `DataSet`;
- Use the `resequence_child` on JS (during update);
- Add the `resequence_child` in the controller.
