### PR TITLE
[12.0][FIX] storage_image: Indefinite error

### DIFF
--- a/storage_image/static/src/js/storage_image.js
+++ b/storage_image/static/src/js/storage_image.js
@@ -37,7 +37,6 @@ odoo.define('storage_image.image_url', function (require) {
             this.$('> img').remove();
             this.$el.prepend($img);
             $img.on('error', function () {
-                self._clearFile();
                 $img.attr('src', self.placeholder);
                 self.do_warn(_t("Image"), _t("Could not display the selected image."));
             });


### PR DESCRIPTION
When the url is not accessible, the error event on
FieldImageUrl object is launched indefintely

Before:

![image](https://user-images.githubusercontent.com/19529533/92581813-6e6bea80-f290-11ea-9b43-977d1901f707.png)


After:

![image](https://user-images.githubusercontent.com/19529533/92581520-13d28e80-f290-11ea-8d20-fcf3f29b6864.png)
