### PR TITLE
[13.0][storage_image_product][fix] sort order to calculate the default image

### DIFF
--- a/storage_image_product/models/product_product.py
+++ b/storage_image_product/models/product_product.py
@@ -11,12 +11,12 @@ class ProductProduct(models.Model):
     # small and medium image are here to replace
     # native image field on form and kanban
     variant_image_small_url = fields.Char(
-        related="variant_image_ids.image_id.image_small_url",
+        compute="_compute_variant_image_ids",
         store=True,
         string="Variant Image Small Url",
     )
     variant_image_medium_url = fields.Char(
-        related="variant_image_ids.image_id.image_medium_url",
+        compute="_compute_variant_image_ids",
         store=True,
         string="Variant Image Medium Url",
     )
@@ -29,12 +29,16 @@ class ProductProduct(models.Model):
 
     @api.depends(
         "product_tmpl_id.image_ids.attribute_value_ids",
+        "product_tmpl_id.image_ids.sequence",
         "product_template_attribute_value_ids",
     )
     def _compute_variant_image_ids(self):
         for variant in self:
             res = self.env["product.image.relation"].browse([])
-            for image in variant.image_ids:
+            variant_images = variant.image_ids.sorted(
+                key=lambda i: (i.sequence, i.image_id)
+            )
+            for image in variant_images:
                 if not (
                     image.attribute_value_ids
                     - variant.mapped(
@@ -43,4 +47,10 @@ class ProductProduct(models.Model):
                     )
                 ):
                     res |= image
+            if res:
+                variant.variant_image_small_url = res[0].image_id.image_small_url
+                variant.variant_image_medium_url = res[0].image_id.image_medium_url
+            else:
+                variant.variant_image_small_url = None
+                variant.variant_image_medium_url = None
             variant.variant_image_ids = res

--- a/storage_image_product/models/product_template.py
+++ b/storage_image_product/models/product_template.py
@@ -5,7 +5,7 @@
 
 import logging
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 _logger = logging.getLogger(__name__)
 
@@ -15,12 +15,21 @@ class ProductTemplate(models.Model):
 
     # small and medium image are here to replace
     # native image field on form and kanban
-    image_small_url = fields.Char(
-        related="image_ids.image_id.image_small_url", store=True
-    )
-    image_medium_url = fields.Char(
-        related="image_ids.image_id.image_medium_url", store=True
-    )
+    image_small_url = fields.Char(compute="_compute_image_urls", store=True)
+    image_medium_url = fields.Char(compute="_compute_image_urls", store=True)
     image_ids = fields.One2many(
         "product.image.relation", inverse_name="product_tmpl_id", string="Images"
     )
+
+    @api.depends("image_ids", "image_ids.sequence", "image_ids.image_id")
+    def _compute_image_urls(self):
+        for template in self:
+            template_images = template.image_ids.sorted(
+                key=lambda i: (i.sequence, i.image_id)
+            )
+            if template_images:
+                template.image_small_url = template_images[0].image_id.image_small_url
+                template.image_medium_url = template_images[0].image_id.image_medium_url
+            else:
+                template.image_small_url = None
+                template.image_medium_url = None


### PR DESCRIPTION
Fixes the sort order of images in the product template and variant, used
to compute the default image displayed in the product.

![image](https://user-images.githubusercontent.com/7683926/105873070-63c1b000-5ffb-11eb-8e6f-b5cda15c4121.png)
