### PR TITLE
[13.0][imp][storage_file] create the image url using report.url if the image is being printed from an odoo report

### DIFF
--- a/storage_file/README.rst
+++ b/storage_file/README.rst
@@ -18,6 +18,9 @@ Use cases (with help of additionnal modules):
 - store pdf (like invoices) on a file server with high SLA
 - access attachments with read/write on prod environment and only read only on dev / testing
 
+If the images are served by Odoo and you want to use them in reports, then you should fetch the image URL
+using context parameter 'storage_image_url_for_report'.
+
 Known issues / Roadmap
 ======================
 

--- a/storage_file/models/storage_file.py
+++ b/storage_file/models/storage_file.py
@@ -144,12 +144,18 @@ class StorageFile(models.Model):
 
     def _get_url(self):
         """Retrieve file URL based on backend params."""
+        url_is_for_report = self.env.context.get("storage_image_url_for_report", False)
         backend = self.backend_id.sudo()
-        parts = []
         if backend.served_by == "odoo":
             params = self.env["ir.config_parameter"].sudo()
+            report_url = params.get_param("report.url") or params.get_param(
+                "web.base.url"
+            )
+            base_url = (
+                report_url if url_is_for_report else params.get_param("web.base.url")
+            )
             parts = [
-                params.get_param("web.base.url"),
+                base_url,
                 "storage.file",
                 self._slugify_name_with_id(),
             ]


### PR DESCRIPTION
Otherwise the report will not be able to display the image, because it is using the base.web_url instead.