### PR TITLE
storage_s3: fix aws regions -> load once

### DIFF
--- a/storage_backend_s3/models/storage_backend.py
+++ b/storage_backend_s3/models/storage_backend.py
@@ -16,6 +16,20 @@ except ImportError as err:  # pragma: no cover
     _logger.debug(err)
 
 
+def _load_aws_regions():
+    _logger.info("Loading available AWS regions")
+    session = boto3.session.Session()
+    return [
+        (region, region.replace("-", " ").capitalize())
+        for region in session.get_available_regions("s3")
+    ]
+
+
+# AWS regions won't change that often, fine to retrieve them at instance load.
+# Also, this prevents to call AWS every time the selection list is accessed.
+AWS_REGIONS = _load_aws_regions()
+
+
 class StorageBackend(models.Model):
     _inherit = "storage.backend"
 
@@ -62,12 +76,8 @@ class StorageBackend(models.Model):
         return env_fields
 
     def _selection_aws_region(self):
-        session = boto3.session.Session()
         return (
             [("", "None")]
-            + [
-                (region, region.replace("-", " ").capitalize())
-                for region in session.get_available_regions("s3")
-            ]
+            + AWS_REGIONS
             + [("other", "Empty or Other (Manually specify below)")]
         )


### PR DESCRIPTION
Every time the selection field was loaded
S3 API were called to retrieve regions.
This can have a big impact on computing URLs
and in any case is useless if we assume
that regions do not change every now and then.