### PR TITLE
storage_file: boost url compute

### DIFF
--- a/storage_file/models/__init__.py
+++ b/storage_file/models/__init__.py
@@ -1,2 +1,3 @@
 from . import storage_file
 from . import storage_backend
+from . import ir_actions_report

--- a/storage_file/models/ir_actions_report.py
+++ b/storage_file/models/ir_actions_report.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com).
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def render_qweb_pdf(self, res_ids=None, data=None):
+        return super(
+            IrActionsReport, self.with_context(print_report_pdf=True)
+        ).render_qweb_pdf(res_ids=res_ids, data=data)

--- a/storage_file/models/storage_backend.py
+++ b/storage_file/models/storage_backend.py
@@ -98,13 +98,18 @@ class StorageBackend(models.Model):
                 parts.append(backend.directory_path)
         return "/".join(parts)
 
+    def _get_base_url_from_param(self):
+        base_url_param = (
+            "report.url" if self.env.context.get("print_report_pdf") else "web.base.url"
+        )
+        return self.env["ir.config_parameter"].sudo().get_param(base_url_param)
+
     def _get_url_for_file(self, storage_file):
         """Return final full URL for given file."""
         backend = self.sudo()
         if backend.served_by == "odoo":
-            params = self.env["ir.config_parameter"].sudo()
             parts = [
-                params.get_param("web.base.url"),
+                self._get_base_url_from_param(),
                 "storage.file",
                 storage_file.slug,
             ]

--- a/storage_file/tests/test_storage_file.py
+++ b/storage_file/tests/test_storage_file.py
@@ -58,6 +58,16 @@ class StorageFileCase(TransactionComponentCase):
         )
         self.assertEqual(stfile, stfile2)
 
+    def test_slug(self):
+        stfile = self._create_storage_file()
+        self.assertEqual(
+            stfile.slug, "test-of-my_file-{}.txt".format(stfile.id),
+        )
+        stfile.name = "Name has changed.png"
+        self.assertEqual(
+            stfile.slug, "name-has-changed-{}.png".format(stfile.id),
+        )
+
     def test_url(self):
         stfile = self._create_storage_file()
         params = self.env["ir.config_parameter"].sudo()
@@ -241,4 +251,4 @@ class StorageFileCase(TransactionComponentCase):
     def test_empty(self):
         # get_url is called on new records
         empty = self.env["storage.file"].new({})._get_url()
-        self.assertEqual(empty, "/")
+        self.assertEqual(empty, "")

--- a/storage_file/tests/test_storage_file.py
+++ b/storage_file/tests/test_storage_file.py
@@ -95,6 +95,16 @@ class StorageFileCase(TransactionComponentCase):
             stfile.url, "https://foo.com/baz/test-of-my_file-{}.txt".format(stfile.id)
         )
 
+    def test_url_for_report(self):
+        stfile = self._create_storage_file()
+        params = self.env["ir.config_parameter"].sudo()
+        params.set_param("report.url", "http://report.url")
+        # served by odoo
+        self.assertEqual(
+            stfile.with_context(print_report_pdf=True).url,
+            "http://report.url/storage.file/test-of-my_file-{}.txt".format(stfile.id),
+        )
+
     def test_create_store_with_hash(self):
         self.backend.filename_strategy = "hash"
         stfile = self._create_storage_file()


### PR DESCRIPTION
URL is always computed because some parts of it might change.

Reading backend data that might come form server env params
or computing all the times the slug using regex can be very consuming.

Certain bits can be stored on their respective records.