### PR TITLE
[13.0][UPD] pre-commit: pump pylint-odoo version (greenify repo)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,11 +80,11 @@ repos:
         name: pylint with optional checks
         args: ["--rcfile=.pylintrc", "--exit-zero"]
         verbose: true
-        additional_dependencies: ["pylint-odoo==3.1.0"]
+        additional_dependencies: ["pylint-odoo==3.5.0"]
       - id: pylint
         name: pylint with mandatory checks
         args: ["--rcfile=.pylintrc-mandatory"]
-        additional_dependencies: ["pylint-odoo==3.1.0"]
+        additional_dependencies: ["pylint-odoo==3.5.0"]
   - repo: https://github.com/asottile/pyupgrade
     rev: v1.26.2
     hooks:


### PR DESCRIPTION
While https://github.com/OCA/storage/pull/90 is not merged (and maybe it will take a while), others PRs CI are red and thus cannot be merged. Let's temporarily proceed with this and unblock other PRs.