### PR TITLE
storage_thumbnail: do not store url

### DIFF
--- a/storage_file/models/storage_backend.py
+++ b/storage_file/models/storage_backend.py
@@ -47,6 +47,24 @@ class StorageBackend(models.Model):
     )
     base_url_for_files = fields.Char(compute="_compute_base_url_for_files", store=True)
 
+    def write(self, vals):
+        # Ensure storage file URLs are up to date
+        clear_url_cache = False
+        url_related_fields = (
+            "served_by",
+            "base_url",
+            "directory_path",
+            "url_include_directory_path",
+        )
+        for fname in url_related_fields:
+            if fname in vals:
+                clear_url_cache = True
+                break
+        res = super().write(vals)
+        if clear_url_cache:
+            self.action_recompute_base_url_for_files()
+        return res
+
     @property
     def _server_env_fields(self):
         env_fields = super()._server_env_fields
@@ -97,6 +115,17 @@ class StorageBackend(models.Model):
             if backend.url_include_directory_path and backend.directory_path:
                 parts.append(backend.directory_path)
         return "/".join(parts)
+
+    def action_recompute_base_url_for_files(self):
+        """Refresh base URL for files.
+
+        Rationale: all the params for computing this URL might come from server env.
+        When this is the case, the URL - being stored - might be out of date.
+        This is because changes to server env fields are not detected at startup.
+        Hence, let's offer an easy way to promptly force this manually when needed.
+        """
+        self._compute_base_url_for_files()
+        self.env["storage.file"].invalidate_cache(["url"])
 
     def _get_base_url_from_param(self):
         base_url_param = (

--- a/storage_file/models/storage_backend.py
+++ b/storage_file/models/storage_backend.py
@@ -144,4 +144,4 @@ class StorageBackend(models.Model):
             ]
         else:
             parts = [backend.base_url_for_files or "", storage_file.relative_path or ""]
-        return "/".join([x for x in parts if x])
+        return "/".join([x.rstrip("/") for x in parts if x])

--- a/storage_file/models/storage_file.py
+++ b/storage_file/models/storage_file.py
@@ -140,9 +140,7 @@ class StorageFile(models.Model):
             else:
                 rec.data = None
 
-    @api.depends(
-        "relative_path", "backend_id.base_url_for_files",
-    )
+    @api.depends("relative_path", "backend_id")
     def _compute_url(self):
         for record in self:
             record.url = record._get_url()

--- a/storage_file/views/storage_backend_view.xml
+++ b/storage_file/views/storage_backend_view.xml
@@ -30,6 +30,29 @@
                     name="url_include_directory_path"
                     attrs="{'invisible': [('directory_path', '=', False)]}"
                 />
+                <field
+                    name="base_url_for_files"
+                    string="Base URL used for files"
+                    attrs="{'invisible':[('served_by', '!=', 'external')]}"
+                />
+                <div
+                    class="alert alert-info"
+                    role="alert"
+                    attrs="{'invisible': [('served_by', '!=', 'external')]}"
+                >
+                    When served by external service you might have special environment configuration
+                    for building final files URLs.
+                    <br />For performance reasons, the base URL is computed and stored.
+                    If you change some parameters (eg: in local dev environment or special instances)
+                    and you still want to see the images you might need to refresh this URL
+                    to make sure images and/or files are loaded correctly.
+                </div>
+                <button
+                    type="object"
+                    name="action_recompute_base_url_for_files"
+                    string="Recompute base URL for files"
+                    help="If you have changed parameters via server env settings the URL might look outdated."
+                />
             </field>
         </field>
     </record>

--- a/storage_image/models/storage_image.py
+++ b/storage_image/models/storage_image.py
@@ -47,6 +47,7 @@ class StorageImage(models.Model):
             vals["backend_id"] = self._get_default_backend_id()
         # When using the widget image_url, the create will pass the data
         # in the "url" field. We map it to the data field
+        # TODO: WHY??? I don't see any handling of `data` as url in storage.file
         for key in ["image_medium_url", "image_small_url"]:
             if key in vals:
                 vals["data"] = vals.pop(key)

--- a/storage_image/tests/test_storage_image.py
+++ b/storage_image/tests/test_storage_image.py
@@ -10,27 +10,29 @@ import requests_mock
 
 from odoo.exceptions import AccessError
 
-from odoo.addons.component.tests.common import TransactionComponentCase
+from odoo.addons.component.tests.common import SavepointComponentCase
 
 
-class StorageImageCase(TransactionComponentCase):
-    def setUp(self):
-        super(StorageImageCase, self).setUp()
+class StorageImageCase(SavepointComponentCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         # FIXME: remove this, should have explicit permission tests
         # Run the test with the demo user in order to check the access right
-        self.user = self.env.ref("base.user_demo")
-        self.user.write(
-            {"groups_id": [(4, self.env.ref("storage_image.group_image_manager").id)]}
+        cls.user = cls.env.ref("base.user_demo")
+        cls.user.write(
+            {"groups_id": [(4, cls.env.ref("storage_image.group_image_manager").id)]}
         )
-        self.env = self.env(user=self.user)
+        cls.env = cls.env(user=cls.user)
 
-        self.backend = self.env.ref("storage_backend.default_storage_backend")
+        cls.backend = cls.env.ref("storage_backend.default_storage_backend")
         path = os.path.dirname(os.path.abspath(__file__))
         with open(os.path.join(path, "static/akretion-logo.png"), "rb") as f:
             data = f.read()
-        self.filesize = len(data)
-        self.filedata = base64.b64encode(data)
-        self.filename = "akretion-logo.png"
+        cls.filesize = len(data)
+        cls.filedata = base64.b64encode(data)
+        cls.filename = "akretion-logo.png"
 
     def _create_storage_image(self):
         return self.env["storage.image"].create(

--- a/storage_image/tests/test_storage_image.py
+++ b/storage_image/tests/test_storage_image.py
@@ -36,12 +36,13 @@ class StorageImageCase(SavepointComponentCase):
 
     def _create_storage_image(self):
         return self.env["storage.image"].create(
-            {"name": self.filename, "image_medium_url": self.filedata}
+            {"name": self.filename, "data": self.filedata}
         )
 
     def _check_thumbnail(self, image):
         self.assertEqual(len(image.thumbnail_ids), 2)
-        medium, small = image.thumbnail_ids
+        medium = image._get_thumb("medium")
+        small = image._get_thumb("small")
         self.assertEqual(medium.size_x, 128)
         self.assertEqual(medium.size_y, 128)
         self.assertEqual(small.size_x, 64)
@@ -126,13 +127,14 @@ class StorageImageCase(SavepointComponentCase):
             m.get("http://pilbox:8888?", text="data")
             image = self._create_storage_image()
             self.assertEqual(len(m.request_history), 2)
-            self.assertEqual(
-                m.request_history[0].url,
+            urls = [x.url for x in m.request_history]
+            self.assertIn(
                 "http://pilbox:8888/?url=test/akretion-logo-%s.png"
                 "&w=128&h=128&mode=fill&fmt=webp" % image.file_id.id,
+                urls,
             )
-            self.assertEqual(
-                m.request_history[1].url,
+            self.assertIn(
                 "http://pilbox:8888/?url=test/akretion-logo-%s.png"
                 "&w=64&h=64&mode=fill&fmt=webp" % image.file_id.id,
+                urls,
             )

--- a/storage_image/views/storage_image_view.xml
+++ b/storage_image/views/storage_image_view.xml
@@ -45,6 +45,8 @@
                     <page name="info" string="File Informations">
                         <group name="info">
                             <field name="file_id" readonly="True" required="False" />
+                            <field name="thumb_medium_id" />
+                            <field name="thumb_small_id" />
                             <field name="thumbnail_ids" readonly="True" />
                         </group>
                     </page>

--- a/storage_image_product/models/product_image_relation.py
+++ b/storage_image_product/models/product_image_relation.py
@@ -35,3 +35,11 @@ class ProductImageRelation(models.Model):
             rec.available_attribute_value_ids = rec.product_tmpl_id.mapped(
                 "attribute_line_ids.value_ids"
             )
+
+    def _match_variant(self, variant):
+        return not bool(
+            self.attribute_value_ids
+            - variant.mapped(
+                "product_template_attribute_value_ids.product_attribute_value_id"
+            )
+        )

--- a/storage_image_product/models/product_product.py
+++ b/storage_image_product/models/product_product.py
@@ -24,8 +24,12 @@ class ProductProduct(models.Model):
     )
     # small and medium image are here to replace
     # native image field on form and kanban
-    variant_image_small_url = fields.Char(related="main_image_id.image_small_url")
-    variant_image_medium_url = fields.Char(related="main_image_id.image_medium_url")
+    variant_image_small_url = fields.Char(
+        string="Variant main small image URL", related="main_image_id.image_small_url"
+    )
+    variant_image_medium_url = fields.Char(
+        string="Variant main medium image URL", related="main_image_id.image_medium_url"
+    )
 
     @api.depends(
         "product_tmpl_id.image_ids.attribute_value_ids",

--- a/storage_image_product/models/product_product.py
+++ b/storage_image_product/models/product_product.py
@@ -1,5 +1,7 @@
 # Copyright 2017 Akretion (http://www.akretion.com).
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# @author Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import api, fields, models
@@ -8,24 +10,22 @@ from odoo import api, fields, models
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
-    # small and medium image are here to replace
-    # native image field on form and kanban
-    variant_image_small_url = fields.Char(
-        compute="_compute_variant_image_ids",
-        store=True,
-        string="Variant Image Small Url",
-    )
-    variant_image_medium_url = fields.Char(
-        compute="_compute_variant_image_ids",
-        store=True,
-        string="Variant Image Medium Url",
-    )
     variant_image_ids = fields.Many2many(
         "product.image.relation",
         compute="_compute_variant_image_ids",
         store=True,
         string="Variant Images",
     )
+    main_image_id = fields.Many2one(
+        "storage.image",
+        compute="_compute_main_image_id",
+        # Store it to improve perf on product views
+        store=True,
+    )
+    # small and medium image are here to replace
+    # native image field on form and kanban
+    variant_image_small_url = fields.Char(related="main_image_id.image_small_url")
+    variant_image_medium_url = fields.Char(related="main_image_id.image_medium_url")
 
     @api.depends(
         "product_tmpl_id.image_ids.attribute_value_ids",
@@ -34,23 +34,22 @@ class ProductProduct(models.Model):
     )
     def _compute_variant_image_ids(self):
         for variant in self:
-            res = self.env["product.image.relation"].browse([])
-            variant_images = variant.image_ids.sorted(
+            img_relations = set()
+            # Not sure sorting is needed here
+            sorted_image_relations = variant.image_ids.sorted(
                 key=lambda i: (i.sequence, i.image_id)
             )
-            for image in variant_images:
-                if not (
-                    image.attribute_value_ids
-                    - variant.mapped(
-                        "product_template_attribute_value_ids."
-                        "product_attribute_value_id"
-                    )
-                ):
-                    res |= image
-            if res:
-                variant.variant_image_small_url = res[0].image_id.image_small_url
-                variant.variant_image_medium_url = res[0].image_id.image_medium_url
-            else:
-                variant.variant_image_small_url = None
-                variant.variant_image_medium_url = None
-            variant.variant_image_ids = res
+            for image_rel in sorted_image_relations:
+                if image_rel._match_variant(variant):
+                    img_relations.add(image_rel.id)
+            variant.variant_image_ids = list(img_relations) if img_relations else False
+
+    @api.depends("variant_image_ids.sequence")
+    def _compute_main_image_id(self):
+        for record in self:
+            record.main_image_id = record._get_main_image()
+
+    def _get_main_image(self):
+        return fields.first(
+            self.variant_image_ids.sorted(key=lambda i: (i.sequence, i.image_id))
+        ).image_id

--- a/storage_image_product/models/product_template.py
+++ b/storage_image_product/models/product_template.py
@@ -28,8 +28,13 @@ class ProductTemplate(models.Model):
     )
     # small and medium image are here to replace
     # native image field on form and kanban
-    image_small_url = fields.Char(related="main_image_id.image_small_url")
-    image_medium_url = fields.Char(related="main_image_id.image_medium_url")
+
+    image_small_url = fields.Char(
+        string="Main small image URL", related="main_image_id.image_small_url"
+    )
+    image_medium_url = fields.Char(
+        string="Main medium image URL", related="main_image_id.image_medium_url"
+    )
 
     @api.depends("image_ids", "image_ids.sequence", "image_ids.image_id")
     def _compute_main_image_id(self):

--- a/storage_image_product/models/product_template.py
+++ b/storage_image_product/models/product_template.py
@@ -1,5 +1,7 @@
 # Copyright 2018 Akretion (http://www.akretion.com).
 # @author Raphaël Reverdy <https://github.com/hparfr>
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# @author Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 
@@ -13,23 +15,28 @@ _logger = logging.getLogger(__name__)
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
+    image_ids = fields.One2many(
+        comodel_name="product.image.relation",
+        inverse_name="product_tmpl_id",
+        string="Images",
+    )
+    main_image_id = fields.Many2one(
+        comodel_name="storage.image",
+        compute="_compute_main_image_id",
+        # Store it to improve perf on product views
+        store=True,
+    )
     # small and medium image are here to replace
     # native image field on form and kanban
-    image_small_url = fields.Char(compute="_compute_image_urls", store=True)
-    image_medium_url = fields.Char(compute="_compute_image_urls", store=True)
-    image_ids = fields.One2many(
-        "product.image.relation", inverse_name="product_tmpl_id", string="Images"
-    )
+    image_small_url = fields.Char(related="main_image_id.image_small_url")
+    image_medium_url = fields.Char(related="main_image_id.image_medium_url")
 
     @api.depends("image_ids", "image_ids.sequence", "image_ids.image_id")
-    def _compute_image_urls(self):
-        for template in self:
-            template_images = template.image_ids.sorted(
-                key=lambda i: (i.sequence, i.image_id)
-            )
-            if template_images:
-                template.image_small_url = template_images[0].image_id.image_small_url
-                template.image_medium_url = template_images[0].image_id.image_medium_url
-            else:
-                template.image_small_url = None
-                template.image_medium_url = None
+    def _compute_main_image_id(self):
+        for record in self:
+            record.main_image_id = record._get_main_image()
+
+    def _get_main_image(self):
+        return fields.first(
+            self.image_ids.sorted(key=lambda i: (i.sequence, i.image_id))
+        ).image_id

--- a/storage_image_product/tests/__init__.py
+++ b/storage_image_product/tests/__init__.py
@@ -1,2 +1,1 @@
 from . import test_product_image_relation
-from . import common

--- a/storage_thumbnail/__manifest__.py
+++ b/storage_thumbnail/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Storage Thumbnail",
     "summary": "Abstract module that add the possibility to have thumbnail",
-    "version": "13.0.1.1.0",
+    "version": "13.0.1.2.0",
     "category": "Storage",
     "website": "https://github.com/OCA/storage",
     "author": " Akretion, Odoo Community Association (OCA)",

--- a/storage_thumbnail/migrations/13.0.1.2.0/pre-migration.py
+++ b/storage_thumbnail/migrations/13.0.1.2.0/pre-migration.py
@@ -1,0 +1,57 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+import logging
+
+from psycopg2.extensions import AsIs
+
+from odoo.tools.sql import column_exists
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    # Get all related tables using thumb mixin
+    _logger.info("Pre-computing new thumbs relations")
+    cr.execute("SELECT DISTINCT res_model FROM storage_thumbnail")
+    res = [x[0] for x in cr.fetchall()]
+    for model in res:
+        # assume table has std name
+        table = model.replace(".", "_")
+        for scale in ("medium", "small"):
+            if not column_exists(cr, table, "thumb_%s_id" % scale):
+                cr.execute(
+                    """
+                    ALTER TABLE
+                        %s
+                    ADD COLUMN
+                        thumb_%s_id int4
+                    REFERENCES
+                        storage_thumbnail(id)
+                    """,
+                    (AsIs(table), AsIs(scale)),
+                )
+                _logger.info("Added thumb %s column to %s", scale, table)
+                _store_relation(cr, table, model, scale)
+                _logger.info("Computed thumb %s relation for %s", scale, table)
+
+
+def _store_relation(cr, table, model, scale):
+    scales = {
+        "medium": (128, 128),
+        "small": (64, 64),
+    }
+    size = scales[scale]
+    query = """
+        UPDATE
+            %s AS rel
+        SET
+            thumb_%s_id = th.id
+        FROM
+            storage_thumbnail AS th
+        WHERE
+            th.res_model = %s
+            AND th.size_x = %s
+            AND th.size_y = %s
+            AND th.res_id = rel.id
+    """
+    cr.execute(query, (AsIs(table), AsIs(scale), model, size[0], size[1]))

--- a/storage_thumbnail/models/storage_thumbnail.py
+++ b/storage_thumbnail/models/storage_thumbnail.py
@@ -19,8 +19,8 @@ class StorageThumbnail(models.Model):
     _inherits = {"storage.file": "file_id"}
     _default_file_type = "thumbnail"
 
-    size_x = fields.Integer("weight")
-    size_y = fields.Integer("height")
+    size_x = fields.Integer("X size")
+    size_y = fields.Integer("Y size")
     url_key = fields.Char(
         "Url key", help="Specific URL key for generating the url of the image"
     )

--- a/storage_thumbnail/models/thumbnail_mixin.py
+++ b/storage_thumbnail/models/thumbnail_mixin.py
@@ -23,14 +23,53 @@ class ThumbnailMixing(models.AbstractModel):
         inverse_name="res_id",
         domain=lambda self: [("res_model", "=", self._name)],
     )
-    image_medium_url = fields.Char(readonly=True)
-    image_small_url = fields.Char(readonly=True)
+    thumb_medium_id = fields.Many2one(
+        comodel_name="storage.thumbnail",
+        compute="_compute_main_thumbs",
+        store=True,
+        readonly=False,
+    )
+    thumb_small_id = fields.Many2one(
+        comodel_name="storage.thumbnail",
+        compute="_compute_main_thumbs",
+        store=True,
+        readonly=False,
+    )
+    image_medium_url = fields.Char(
+        string="Medium thumb URL", related="thumb_medium_id.url"
+    )
+    image_small_url = fields.Char(
+        string="Small thumb URL", related="thumb_small_id.url"
+    )
+
+    _image_scale_mapping = {
+        "medium": (128, 128),
+        "small": (64, 64),
+    }
+
+    @api.depends("thumbnail_ids.size_x", "thumbnail_ids.size_y")
+    def _compute_main_thumbs(self):
+        for rec in self:
+            for scale in self._image_scale_mapping.keys():
+                fname = "thumb_%s_id" % scale
+                rec[fname] = self._get_thumb(scale_key=scale)
+
+    def _get_thumb(self, scale_key=None, scale=None):
+        """Retrievet the first thumb matching given scale.
+
+        """
+        assert scale_key or scale
+        scale = scale or self._image_scale_mapping[scale_key]
+        size_x, size_y = scale
+        for thumb in self.thumbnail_ids:
+            if thumb.size_x == size_x and thumb.size_y == size_y:
+                return thumb
 
     def _get_medium_thumbnail(self):
-        return self.get_or_create_thumbnail(128, 128)
+        return self.get_or_create_thumbnail(*self._image_scale_mapping["medium"])
 
     def _get_small_thumbnail(self):
-        return self.get_or_create_thumbnail(64, 64)
+        return self.get_or_create_thumbnail(*self._image_scale_mapping["small"])
 
     def get_or_create_thumbnail(self, size_x, size_y, url_key=None):
         self.ensure_one()
@@ -58,12 +97,8 @@ class ThumbnailMixing(models.AbstractModel):
 
     def generate_odoo_thumbnail(self):
         self_sudo = self.sudo()
-        self.write(
-            {
-                "image_medium_url": self_sudo._get_medium_thumbnail().url,
-                "image_small_url": self_sudo._get_small_thumbnail().url,
-            }
-        )
+        self_sudo._get_small_thumbnail()
+        self_sudo._get_medium_thumbnail()
         return True
 
     @api.model

--- a/storage_thumbnail/tests/models.py
+++ b/storage_thumbnail/tests/models.py
@@ -23,7 +23,4 @@ class ModelTest(models.TransientModel):
         vals["file_type"] = "thumbnail"
         if "backend_id" not in vals:
             vals.update({"backend_id": self._get_backend_id()})
-        for key in ["image_medium_url", "image_small_url"]:
-            if key in vals:
-                vals["data"] = vals.pop(key)
         return super().create(vals)

--- a/storage_thumbnail/tests/test_thumbnail.py
+++ b/storage_thumbnail/tests/test_thumbnail.py
@@ -32,32 +32,38 @@ class TestStorageThumbnail(SavepointComponentCase):
     def _create_thumbnail(self):
         # create thumbnail
         vals = {"name": "TEST THUMB"}
-        self.thumbnail = self.env["storage.thumbnail"].create(vals)
+        return self.env["storage.thumbnail"].create(vals)
 
-    def _create_model(self, resize=False):
+    def _create_image(self, resize=False):
         if resize:
             self.env["ir.config_parameter"].sudo().create(
                 {"key": "storage.image.resize.format", "value": ".webp"}
             )
-        vals = {"name": self.filename, "image_medium_url": self.filedata}
-        self.image = self.env["model.test"].create(vals)
+        vals = {"name": self.filename, "data": self.filedata}
+        return self.env["model.test"].create(vals)
 
     def test_thumbnail(self):
-        self._create_thumbnail()
-        self.assertTrue(self.thumbnail.url)
-        file_id = self.thumbnail.file_id
+        thumb = self._create_thumbnail()
+        self.assertTrue(thumb.url)
+        file_id = thumb.file_id
         self.assertTrue(file_id)
-
-        self.thumbnail.unlink()
+        thumb.unlink()
         self.assertTrue(file_id.to_delete)
 
     def test_model(self):
-        self._create_model()
-        self.assertTrue(self.image.url)
-        self.assertEquals(2, len(self.image.thumbnail_ids))
-        self.assertEquals(".png", first(self.image.thumbnail_ids).extension)
+        image = self._create_image()
+        self.assertTrue(image.url)
+        self.assertEquals(2, len(image.thumbnail_ids))
+        self.assertEquals(".png", first(image.thumbnail_ids).extension)
 
     def test_model_resize(self):
-        self._create_model(resize=True)
-        self.assertIn("webp", first(self.image.thumbnail_ids).url)
-        self.assertEquals(".webp", first(self.image.thumbnail_ids).extension)
+        image = self._create_image(resize=True)
+        self.assertIn("webp", first(image.thumbnail_ids).url)
+        self.assertEquals(".webp", first(image.thumbnail_ids).extension)
+
+    def test_medium_small(self):
+        image = self._create_image()
+        self.assertEqual(image.thumb_medium_id.size_x, 128)
+        self.assertEqual(image.thumb_medium_id.size_y, 128)
+        self.assertEqual(image.thumb_small_id.size_x, 64)
+        self.assertEqual(image.thumb_small_id.size_y, 64)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 requests_mock
 vcrpy-unittest
+odoo_test_helper


### PR DESCRIPTION
The URL for all storage files is normally computed via backend.
This ensures that if you have different conf by env
you won't mess up w/ images coming from other envs (eg: prod).

This change makes sure that the URL which is used for the thumbs
is always computed by the backend.