### PR TITLE
[12.0][FIX] storage_image: more robust security rule + FIX 12.0 repository configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,17 +36,17 @@ repos:
   - id: mixed-line-ending
     args: ["--fix=lf"]
 - repo: https://github.com/pre-commit/mirrors-pylint
-  rev: v2.3.1
+  rev: v2.5.3
   hooks:
   - id: pylint
     name: pylint with optional checks
     args: ["--rcfile=.pylintrc", "--exit-zero"]
     verbose: true
-    additional_dependencies: ["pylint-odoo==3.0.3"]
+    additional_dependencies: ["pylint-odoo==3.5.0"]
   - id: pylint
     name: pylint with mandatory checks
     args: ["--rcfile=.pylintrc-mandatory"]
-    additional_dependencies: ["pylint-odoo==3.0.3"]
+    additional_dependencies: ["pylint-odoo==3.5.0"]
 - repo: https://github.com/asottile/pyupgrade
   rev: v1.24.0
   hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   - $HOME/.cache/pre-commit
 
 python:
-  - "3.5"
+  - "3.6"
 
 addons:
   postgresql: "9.6"

--- a/storage_image/security/ir_rule.xml
+++ b/storage_image/security/ir_rule.xml
@@ -5,7 +5,7 @@
     <field name="name">Storage File for Image</field>
     <field name="model_id" ref="model_storage_file"/>
     <field name="domain_force">[('file_type','in', ('image', 'thumbnail'))]</field>
-    <field name="perm_read" eval="0"/>
+    <field name="perm_read" eval="1"/>
     <field name="perm_create" eval="1"/>
     <field name="perm_write" eval="1"/>
     <field name="perm_unlink" eval="1"/>


### PR DESCRIPTION
The fact that this rules does not apply in read means
that a create could have laxer restrictions than a read;
meaning that a create could actually fail on an access rights error.
This is actually the case when installing for example storage media.