### PR TITLE
[13.0][FIX] storage_image: delete relation when image is deleted

### DIFF
--- a/storage_image/models/storage_relation_abstract.py
+++ b/storage_image/models/storage_relation_abstract.py
@@ -16,7 +16,7 @@ class ImageRelationAbstract(models.AbstractModel):
     _order = "sequence, image_id"
 
     sequence = fields.Integer()
-    image_id = fields.Many2one("storage.image", required=True)
+    image_id = fields.Many2one("storage.image", required=True, ondelete="cascade")
     # for kanban view
     image_name = fields.Char(related="image_id.name")
     # for kanban view


### PR DESCRIPTION
Deleting an image from the storage image menu doesn't delete the relation, and the image is still referenced.