### PR TITLE
[13.0][FIX] storage_media: Explicit ir rule definition for Storage File for Media

### DIFF
--- a/storage_media/security/ir_rule.xml
+++ b/storage_media/security/ir_rule.xml
@@ -6,6 +6,10 @@
     <field name="model_id" ref="storage_file.model_storage_file" />
     <field name="domain_force">[('file_type','=', 'media')]</field>
     <field name="groups" eval="[(4, ref('storage_media.group_media_manager'))]" />
+    <field name="perm_read" eval="False" />
+    <field name="perm_write" eval="True" />
+    <field name="perm_create" eval="True" />
+    <field name="perm_unlink" eval="True" />
 </record>
 
 </odoo>


### PR DESCRIPTION
If Apply for Read is kept it collides with Read for Public Users when storage backend is public.

CC @ForgeFlow 