### PR TITLE
[12.0] ADD attachment_db_by_checksum

### DIFF
--- a/attachment_db_by_checksum/__init__.py
+++ b/attachment_db_by_checksum/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/attachment_db_by_checksum/__manifest__.py
+++ b/attachment_db_by_checksum/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "DB attachments saved by checksum",
     "summary": "Allow to identify database attachments through their hash, "
                "avoiding duplicates",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "development_status": "Beta",
     "category": "Storage",
     "website": "https://github.com/OCA/storage",

--- a/attachment_db_by_checksum/__manifest__.py
+++ b/attachment_db_by_checksum/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "DB attachments saved by checksum",
     "summary": "Allow to identify database attachments through their hash, "
-               "avoiding duplicates",
+    "avoiding duplicates",
     "version": "12.0.1.0.1",
     "development_status": "Beta",
     "category": "Storage",
@@ -13,10 +13,6 @@
     "license": "LGPL-3",
     "application": False,
     "installable": True,
-    "depends": [
-        "base",
-    ],
-    "data": [
-        "security/ir.model.access.csv",
-    ],
+    "depends": ["base"],
+    "data": ["security/ir.model.access.csv"],
 }

--- a/attachment_db_by_checksum/__manifest__.py
+++ b/attachment_db_by_checksum/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2021 Lorenzo Battistini @ TAKOBI
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+{
+    "name": "DB attachments saved by checksum",
+    "summary": "Allow to identify database attachments through their hash, "
+               "avoiding duplicates",
+    "version": "12.0.1.0.0",
+    "development_status": "Beta",
+    "category": "Storage",
+    "website": "https://github.com/OCA/storage",
+    "author": "TAKOBI, Odoo Community Association (OCA)",
+    "maintainers": ["eLBati"],
+    "license": "LGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "base",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+    ],
+}

--- a/attachment_db_by_checksum/migrations/12.0.1.0.1/post-migration.py
+++ b/attachment_db_by_checksum/migrations/12.0.1.0.1/post-migration.py
@@ -1,4 +1,4 @@
-from odoo import api, SUPERUSER_ID
+from odoo import SUPERUSER_ID, api
 
 
 def migrate(cr, version):
@@ -6,13 +6,14 @@ def migrate(cr, version):
         return
     with api.Environment.manage():
         env = api.Environment(cr, SUPERUSER_ID, {})
-        contents = env['ir.attachment.content'].search([])
+        contents = env["ir.attachment.content"].search([])
         for content in contents:
-            attachments = env['ir.attachment'].search([
-                ('store_fname', 'like', content.checksum),
-                "|",
-                ("res_field", '=', False),
-                ("res_field", "!=", False)
-            ])
-            # già controllato che non ci sono state perdite di file con checksum molto simili
+            attachments = env["ir.attachment"].search(
+                [
+                    ("store_fname", "like", content.checksum),
+                    "|",
+                    ("res_field", "=", False),
+                    ("res_field", "!=", False),
+                ]
+            )
             content.checksum = attachments[0].store_fname

--- a/attachment_db_by_checksum/migrations/12.0.1.0.1/post-migration.py
+++ b/attachment_db_by_checksum/migrations/12.0.1.0.1/post-migration.py
@@ -1,0 +1,18 @@
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        contents = env['ir.attachment.content'].search([])
+        for content in contents:
+            attachments = env['ir.attachment'].search([
+                ('store_fname', 'like', content.checksum),
+                "|",
+                ("res_field", '=', False),
+                ("res_field", "!=", False)
+            ])
+            # già controllato che non ci sono state perdite di file con checksum molto simili
+            content.checksum = attachments[0].store_fname

--- a/attachment_db_by_checksum/models/__init__.py
+++ b/attachment_db_by_checksum/models/__init__.py
@@ -1,0 +1,2 @@
+from . import ir_attachment_content
+from . import ir_attachment

--- a/attachment_db_by_checksum/models/ir_attachment.py
+++ b/attachment_db_by_checksum/models/ir_attachment.py
@@ -1,0 +1,72 @@
+import logging
+from odoo import models, api, _
+from odoo.exceptions import AccessError
+
+_logger = logging.getLogger(__name__)
+
+
+class Attachment(models.Model):
+    _inherit = "ir.attachment"
+
+    @api.model
+    def _file_write(self, value, checksum):
+        location = self._storage()
+        if location != "hashed_db":
+            return super(Attachment, self)._file_write(value, checksum)
+        fname, _ = self._get_path(False, checksum)
+        att = self.env["ir.attachment.content"].search([
+            ("checksum", "=", fname)
+        ], limit=1)
+        if not att:
+            self.env["ir.attachment.content"].create({
+                "checksum": fname,
+                "db_datas": value,
+            })
+        return fname
+
+    @api.model
+    def _file_read(self, checksum, bin_size=False):
+        location = self._storage()
+        if location != "hashed_db":
+            return super(Attachment, self)._file_read(checksum, bin_size)
+        att = self.env["ir.attachment.content"].search([
+            ("checksum", "=", checksum)
+        ])
+        if not att:
+            _logger.debug("File %s not found" % checksum)
+            return super(Attachment, self)._file_read(checksum, bin_size)
+        return att.db_datas
+
+    @api.model
+    def _file_delete(self, checksum):
+        location = self._storage()
+        if location == "hashed_db":
+            attachments = self.search([
+                ("store_fname", "=", checksum)
+            ])
+            if not attachments:
+                self.env["ir.attachment.content"].search([
+                    ("checksum", "=", checksum)
+                ]).unlink()
+        return super(Attachment, self)._file_delete(checksum)
+
+    @api.model
+    def force_storage(self):
+        if not self.env.user._is_admin():
+            raise AccessError(_("Only administrators can execute this action."))
+        location = self._storage()
+        if location == "hashed_db":
+            # we don't know if previous storage was file system or DB:
+            # we run for every attachment
+            for attach in self.search([
+                # trick to get every attachment, see _search method of ir.attachment
+                "|", ("res_field", '=', False), ("res_field", "!=", False)
+            ]):
+                attach.write({
+                    "datas": attach.datas,
+                    # do not try to guess mimetype overwriting existing value
+                    "mimetype": attach.mimetype,
+                })
+            return True
+        else:
+            return super(Attachment, self).force_storage()

--- a/attachment_db_by_checksum/models/ir_attachment.py
+++ b/attachment_db_by_checksum/models/ir_attachment.py
@@ -41,8 +41,12 @@ class Attachment(models.Model):
     def _file_delete(self, checksum):
         location = self._storage()
         if location == "hashed_db":
+            # see force_storage
             attachments = self.search([
-                ("store_fname", "=", checksum)
+                ("store_fname", "=", checksum),
+                "|",
+                ("res_field", '=', False),
+                ("res_field", "!=", False)
             ])
             if not attachments:
                 self.env["ir.attachment.content"].search([

--- a/attachment_db_by_checksum/models/ir_attachment_content.py
+++ b/attachment_db_by_checksum/models/ir_attachment_content.py
@@ -7,7 +7,7 @@ class AttachmentContent(models.Model):
     _description = "Attachment content by hash"
 
     checksum = fields.Char(
-        "Checksum/SHA1", size=40, index=True, readonly=True, required=True)
+        "Checksum/SHA1", index=True, readonly=True, required=True)
     db_datas = fields.Binary("Database Data")
 
     _sql_constraints = [(

--- a/attachment_db_by_checksum/models/ir_attachment_content.py
+++ b/attachment_db_by_checksum/models/ir_attachment_content.py
@@ -1,0 +1,16 @@
+from odoo import models, fields
+
+
+class AttachmentContent(models.Model):
+    _name = "ir.attachment.content"
+    _rec_name = "checksum"
+    _description = "Attachment content by hash"
+
+    checksum = fields.Char(
+        "Checksum/SHA1", size=40, index=True, readonly=True, required=True)
+    db_datas = fields.Binary("Database Data")
+
+    _sql_constraints = [(
+        'checksum_uniq', 'unique(checksum)',
+        'The checksum of the file must be unique !'
+    )]

--- a/attachment_db_by_checksum/models/ir_attachment_content.py
+++ b/attachment_db_by_checksum/models/ir_attachment_content.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import fields, models
 
 
 class AttachmentContent(models.Model):
@@ -6,11 +6,13 @@ class AttachmentContent(models.Model):
     _rec_name = "checksum"
     _description = "Attachment content by hash"
 
-    checksum = fields.Char(
-        "Checksum/SHA1", index=True, readonly=True, required=True)
+    checksum = fields.Char("Checksum/SHA1", index=True, readonly=True, required=True)
     db_datas = fields.Binary("Database Data")
 
-    _sql_constraints = [(
-        'checksum_uniq', 'unique(checksum)',
-        'The checksum of the file must be unique !'
-    )]
+    _sql_constraints = [
+        (
+            "checksum_uniq",
+            "unique(checksum)",
+            "The checksum of the file must be unique !",
+        )
+    ]

--- a/attachment_db_by_checksum/readme/CONFIGURE.rst
+++ b/attachment_db_by_checksum/readme/CONFIGURE.rst
@@ -1,0 +1,3 @@
+Set system parameter ``ir_attachment.location`` to ``hashed_db`` to activate saving by checksum.
+
+Run ``force_storage``, method of ``ir.attachment``, to move existing attachments.

--- a/attachment_db_by_checksum/readme/CONTRIBUTORS.rst
+++ b/attachment_db_by_checksum/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `TAKOBI <https://takobi.online>`_:
+
+  * Lorenzo Battistini

--- a/attachment_db_by_checksum/readme/DESCRIPTION.rst
+++ b/attachment_db_by_checksum/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+Allow to identify database attachments through their hash, avoiding duplicates.
+
+This is typically useful when you want to save attachments to database but you want to save space avoiding to write the same content in several attachments (think of email attachments, for example, or any file uploaded more than once).

--- a/attachment_db_by_checksum/security/ir.model.access.csv
+++ b/attachment_db_by_checksum/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_ir_attachment_all","ir_attachment all","model_ir_attachment_content",,1,0,0,0
+"access_ir_attachment_group_user","ir_attachment group_user","model_ir_attachment_content","base.group_user",1,1,1,1
+"access_ir_attachment_portal","ir.attachment.portal","model_ir_attachment_content","base.group_portal",1,0,1,0

--- a/setup/attachment_db_by_checksum/odoo/addons/attachment_db_by_checksum
+++ b/setup/attachment_db_by_checksum/odoo/addons/attachment_db_by_checksum
@@ -1,0 +1,1 @@
+../../../../attachment_db_by_checksum

--- a/setup/attachment_db_by_checksum/setup.py
+++ b/setup/attachment_db_by_checksum/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
DB attachments saved by checksum

Allow to identify database attachments through their hash, avoiding duplicates