### PR TITLE
[13.0][IMP] storage_image and storage_thumbnail: Restrict file unlink

### DIFF
--- a/storage_image/models/storage_image.py
+++ b/storage_image/models/storage_image.py
@@ -63,6 +63,8 @@ class StorageImage(models.Model):
         files = self.mapped("file_id")
         thumbnails = self.mapped("thumbnail_ids")
         super(StorageImage, self).unlink()
+        files_linked_to_images = self.search([("file_id", "in", files.ids)])
+        if not files_linked_to_images:
+            files.unlink()
         thumbnails.unlink()
-        files.unlink()
         return True

--- a/storage_thumbnail/models/storage_thumbnail.py
+++ b/storage_thumbnail/models/storage_thumbnail.py
@@ -82,5 +82,7 @@ class StorageThumbnail(models.Model):
     def unlink(self):
         files = self.mapped("file_id")
         result = super().unlink()
-        files.unlink()
+        thumbnail_linked_to_images = self.search([("file_id", "in", files.ids)])
+        if not thumbnail_linked_to_images:
+            files.unlink()
         return result


### PR DESCRIPTION
There could be the situation where and specific storage.file record is used by more than one storage.image or storage.thumbnail. This PR aims to take into account this situation and restrict the file deletion.

CC @ForgeFlow 