### PR TITLE
[IMP] storage_backend: Avoid FileNotFoundError when deleting files on filestore

### DIFF
--- a/storage_backend/components/filesystem_adapter.py
+++ b/storage_backend/components/filesystem_adapter.py
@@ -2,12 +2,15 @@
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+import logging
 import os
 
 from odoo import _
 from odoo.exceptions import AccessError
 
 from odoo.addons.component.core import Component
+
+_logger = logging.getLogger(__name__)
 
 
 def is_safe_path(basedir, path):
@@ -56,4 +59,7 @@ class FileSystemStorageBackend(Component):
 
     def delete(self, relative_path):
         full_path = self._fullpath(relative_path)
-        os.remove(full_path)
+        try:
+            os.remove(full_path)
+        except FileNotFoundError:
+            _logger.warning("File not found in %s", full_path)


### PR DESCRIPTION
It should not happen, but, why not if file is not on the system just continue with the cleanup

CC @ForgeFlow 