### PR TITLE
storage_thumbnail: use internal URL on demand

### DIFF
--- a/storage_file/models/storage_backend.py
+++ b/storage_file/models/storage_backend.py
@@ -46,6 +46,11 @@ class StorageBackend(models.Model):
         "the path will be used to compute the public URL.",
     )
     base_url_for_files = fields.Char(compute="_compute_base_url_for_files", store=True)
+    backend_view_use_internal_url = fields.Boolean(
+        help="Decide if Odoo backend views should use the external URL (usually a CDN) "
+        "or the internal url with direct access to the storage. "
+        "This could save you some money if you pay by CDN traffic."
+    )
 
     def write(self, vals):
         # Ensure storage file URLs are up to date

--- a/storage_file/models/storage_file.py
+++ b/storage_file/models/storage_file.py
@@ -34,6 +34,10 @@ class StorageFile(models.Model):
         "storage.backend", "Storage", index=True, required=True
     )
     url = fields.Char(compute="_compute_url", help="HTTP accessible path to the file")
+    internal_url = fields.Char(
+        compute="_compute_internal_url",
+        help="HTTP URL to load the file directly from storage.",
+    )
     slug = fields.Char(
         compute="_compute_slug", help="Slug-ified name with ID for URL", store=True
     )
@@ -88,9 +92,9 @@ class StorageFile(models.Model):
             record.slug = record._slugify_name_with_id()
 
     def _slugify_name_with_id(self):
-        return u"{}{}".format(
+        return "{}{}".format(
             slugify(
-                u"{}-{}".format(self.filename, self.id), regex_pattern=REGEX_SLUGIFY
+                "{}-{}".format(self.filename, self.id), regex_pattern=REGEX_SLUGIFY
             ),
             self.extension,
         )
@@ -148,6 +152,19 @@ class StorageFile(models.Model):
     def _get_url(self):
         """Retrieve file URL based on backend params."""
         return self.backend_id._get_url_for_file(self)
+
+    @api.depends("slug")
+    def _compute_internal_url(self):
+        for record in self:
+            record.internal_url = record._get_internal_url()
+
+    def _get_internal_url(self):
+        """Retrieve file URL to load file directly from the storage.
+
+        It is recommended to use this for Odoo backend internal usage
+        to not generate traffic on external services.
+        """
+        return f"/storage.file/{self.slug}"
 
     @api.depends("name")
     def _compute_extract_filename(self):

--- a/storage_file/tests/test_storage_file.py
+++ b/storage_file/tests/test_storage_file.py
@@ -70,6 +70,22 @@ class StorageFileCase(TransactionComponentCase):
             "name-has-changed-{}.png".format(stfile.id),
         )
 
+    def test_internal_url(self):
+        stfile = self._create_storage_file()
+        self.assertEqual(
+            stfile.internal_url,
+            "/storage.file/test-of-my_file-{}.txt".format(stfile.id),
+        )
+        stfile.name = "Name has changed.png"
+        self.assertEqual(
+            stfile.slug,
+            "name-has-changed-{}.png".format(stfile.id),
+        )
+        self.assertEqual(
+            stfile.internal_url,
+            "/storage.file/name-has-changed-{}.png".format(stfile.id),
+        )
+
     def test_url(self):
         stfile = self._create_storage_file()
         params = self.env["ir.config_parameter"].sudo()

--- a/storage_file/views/storage_backend_view.xml
+++ b/storage_file/views/storage_backend_view.xml
@@ -24,6 +24,7 @@
                     attrs="{'invisible':[('served_by', '!=', 'external')]}"
                 />
                 <field name="filename_strategy" />
+                <field name="backend_view_use_internal_url" />
             </field>
             <field name="directory_path" position="after">
                 <field

--- a/storage_image_product/models/product_template.py
+++ b/storage_image_product/models/product_template.py
@@ -22,8 +22,11 @@ class ProductTemplate(models.Model):
         # Store it to improve perf on product views
         store=True,
     )
-    # small and medium image are here to replace
-    # native image field on form and kanban
+    # Small and medium image are here to replace
+    # native image field on form and kanban.
+    # Depending on `backend.backend_view_use_internal_url` flag
+    # these URLs might be internal (served by odoo) or public (served by CDN).
+    # See `thumbnail.mixin._compute_thumb_urls`
     image_small_url = fields.Char(
         string="Main small image URL", related="main_image_id.image_small_url"
     )

--- a/storage_thumbnail/models/thumbnail_mixin.py
+++ b/storage_thumbnail/models/thumbnail_mixin.py
@@ -28,20 +28,20 @@ class ThumbnailMixing(models.AbstractModel):
         compute="_compute_main_thumbs",
         store=True,
         readonly=False,
+        compute_sudo=True,
     )
     thumb_small_id = fields.Many2one(
         comodel_name="storage.thumbnail",
         compute="_compute_main_thumbs",
         store=True,
         readonly=False,
+        compute_sudo=True,
     )
     image_medium_url = fields.Char(
-        string="Medium thumb URL",
-        compute="_compute_thumb_urls",
+        string="Medium thumb URL", compute="_compute_thumb_urls", compute_sudo=True
     )
     image_small_url = fields.Char(
-        string="Small thumb URL",
-        compute="_compute_thumb_urls",
+        string="Small thumb URL", compute="_compute_thumb_urls", compute_sudo=True
     )
 
     _image_scale_mapping = {


### PR DESCRIPTION
Using the external URL for internal usage (eg: backend views)
generates useless traffic over CDN which might be costly.

Now you can configure on the backend if you want to use the internal url or the public one.