### PR TITLE
[13.0][IMP] storage_image_product: Remove image attributes unlinked from product template

### DIFF
--- a/storage_image_product/__manifest__.py
+++ b/storage_image_product/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Storage Image Product",
     "summary": "Link images to products and categories",
-    "version": "13.0.2.1.0",
+    "version": "13.0.3.0.0",
     "category": "Storage",
     "website": "https://github.com/OCA/storage",
     "author": " Akretion, Odoo Community Association (OCA)",

--- a/storage_image_product/migrations/13.0.3.0.0/pre-migration.py
+++ b/storage_image_product/migrations/13.0.3.0.0/pre-migration.py
@@ -1,0 +1,40 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """
+    Remove attribute values from product relation image that are not
+    used anymore in product template attributes.
+    """
+    openupgrade.logged_query(
+        env.cr,
+        """
+        WITH sub AS (
+            SELECT rel.product_attribute_value_id, rel.product_image_relation_id
+            FROM product_attribute_value_product_image_relation_rel rel
+            JOIN product_image_relation pir
+                ON pir.id = rel.product_image_relation_id
+            JOIN product_template_attribute_line ptal
+                ON ptal.product_tmpl_id = pir.product_tmpl_id
+            JOIN product_attribute_value_product_template_attribute_line_rel rel2
+                ON rel2.product_template_attribute_line_id = ptal.id
+            JOIN product_attribute_value pav ON (
+                rel2.product_attribute_value_id = pav.id
+                AND pav.attribute_id = ptal.attribute_id
+                AND rel.product_attribute_value_id = pav.id
+            )
+        )
+        DELETE FROM product_attribute_value_product_image_relation_rel rel0
+        USING product_attribute_value_product_image_relation_rel rel
+        LEFT JOIN sub ON (
+            sub.product_attribute_value_id = rel.product_attribute_value_id
+            AND sub.product_image_relation_id = rel.product_image_relation_id)
+        WHERE rel0.product_attribute_value_id = rel.product_attribute_value_id
+            AND rel0.product_image_relation_id = rel.product_image_relation_id
+            AND sub.product_attribute_value_id IS NULL
+        """,
+    )

--- a/storage_image_product/models/__init__.py
+++ b/storage_image_product/models/__init__.py
@@ -1,5 +1,6 @@
 from . import product_image_relation
 from . import product_template
+from . import product_template_attribute_line
 from . import product_product
 from . import product_category
 from . import category_image_relation

--- a/storage_image_product/models/product_template_attribute_line.py
+++ b/storage_image_product/models/product_template_attribute_line.py
@@ -1,0 +1,21 @@
+from odoo import models
+
+
+class ProductTemplateAttributeLine(models.Model):
+
+    _inherit = "product.template.attribute.line"
+
+    def write(self, values):
+        res = super().write(values)
+        if "value_ids" in values:
+            product_image_attribute_value_ids = self.product_tmpl_id.image_ids.mapped(
+                "attribute_value_ids"
+            ).filtered(lambda x: x.attribute_id == self.attribute_id)
+            available_attribute_values_ids = values["value_ids"][0][2] or [0]
+            to_remove = product_image_attribute_value_ids.filtered(
+                lambda x: x.id not in available_attribute_values_ids
+            )
+            if to_remove:
+                for image in self.product_tmpl_id.image_ids:
+                    image.attribute_value_ids -= to_remove
+        return res

--- a/storage_image_product/tests/test_product_image_relation.py
+++ b/storage_image_product/tests/test_product_image_relation.py
@@ -150,3 +150,41 @@ class ProductImageCase(ProductImageCommonCase):
         self._test_main_images_and_urls(expected)
         expected = ((self.logo_image, self.product_c + self.product_a),)
         self._test_main_images_and_urls(expected)
+
+    def test_drop_template_attribute_value_propagation_to_image(self):
+        black_image = self.env["product.image.relation"].create(
+            {
+                "product_tmpl_id": self.template.id,
+                "image_id": self.black_image.id,
+                "attribute_value_ids": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.env.ref("product.product_attribute_value_4").id,
+                            self.env.ref("product.product_attribute_value_1").id,
+                        ],
+                    )
+                ],
+                "sequence": 10,
+            }
+        )
+        # Remove Color black from variant tab:
+        self.template.attribute_line_ids.filtered(
+            lambda x: x.display_name == "Color"
+        ).value_ids -= self.env.ref("product.product_attribute_value_4")
+        # Attribute black is removed from image:
+        self.assertTrue(
+            self.env.ref("product.product_attribute_value_4")
+            not in black_image.attribute_value_ids
+        )
+
+        # Remove Leg attribute line from variant tab:
+        self.template.attribute_line_ids.filtered(
+            lambda x: x.display_name == "Legs"
+        ).unlink()
+        # Product image attribute values from Legs are removed:
+        self.assertTrue(
+            self.env.ref("product.product_attribute_value_1")
+            not in black_image.attribute_value_ids
+        )


### PR DESCRIPTION
CC @ForgeFlow 

- [x] Add migration script to cleanup dangling product image attributes