### PR TITLE
[FIX] storage_backend_ftp: use full path in ``move_files()``

### DIFF
--- a/storage_backend/components/base_adapter.py
+++ b/storage_backend/components/base_adapter.py
@@ -15,10 +15,10 @@ class BaseStorageAdapter(AbstractComponent):
     _collection = "storage.backend"
 
     def _fullpath(self, relative_path):
-        if self.collection.directory_path:
-            return os.path.join(self.collection.directory_path or "", relative_path)
-        else:
+        dp = self.collection.directory_path
+        if not dp or relative_path.startswith(dp):
             return relative_path
+        return os.path.join(dp, relative_path)
 
     def add(self, relative_path, data, **kwargs):
         raise NotImplementedError

--- a/storage_backend_ftp/components/ftp_adapter.py
+++ b/storage_backend_ftp/components/ftp_adapter.py
@@ -136,6 +136,7 @@ class FTPStorageBackendAdapter(Component):
 
     def move_files(self, files, destination_path):
         _logger.debug("mv %s %s", files, destination_path)
+        fp = self._fullpath
         with ftp(self.collection) as client:
             for ftp_file in files:
                 dest_file_path = os.path.join(
@@ -150,8 +151,8 @@ class FTPStorageBackendAdapter(Component):
                     _logger.debug("destination %s is free", dest_file_path)
                 if result:
                     client.delete(dest_file_path)
-                # Move the file
-                client.rename(ftp_file, dest_file_path)
+                # Move the file using absolute filepaths
+                client.rename(fp(ftp_file), fp(dest_file_path))
 
     def delete(self, relative_path):
         full_path = self._fullpath(relative_path)

--- a/storage_backend_ftp/tests/test_ftp.py
+++ b/storage_backend_ftp/tests/test_ftp.py
@@ -120,7 +120,9 @@ class FtpCase(CommonCase, BackendStorageTestMixin):
         # no need to delete it
         client.delete.assert_not_called()
         # rename gets called
-        client.rename.assert_called_with(to_move, to_move.replace("from", "to"))
+        client.rename.assert_called_with(
+            "upload/" + to_move, "upload/" + to_move.replace("from", "to")
+        )
         # now try to override destination
         client.nlst.side_effect = None
         client.nlst.return_value = True
@@ -128,7 +130,9 @@ class FtpCase(CommonCase, BackendStorageTestMixin):
         # client will delete it first
         client.delete.assert_called_with(to_move.replace("from", "to"))
         # then move it
-        client.rename.assert_called_with(to_move, to_move.replace("from", "to"))
+        client.rename.assert_called_with(
+            "upload/" + to_move, "upload/" + to_move.replace("from", "to")
+        )
 
     @mock.patch(FTP_LIB_PATH)
     def test_delete(self, mocked_ftplib):


### PR DESCRIPTION
Backport of #178 