### PR TITLE
[15.0][FIX] storage_backend_sftp: Fix paramiko usage

### DIFF
--- a/storage_backend_sftp/components/sftp_adapter.py
+++ b/storage_backend_sftp/components/sftp_adapter.py
@@ -76,14 +76,14 @@ class SFTPStorageBackendAdapter(Component):
                         sftp_mkdirs(client, dirname)
                     else:
                         raise  # pragma: no cover
-            remote_file = client.open(full_path, "w+b")
+            remote_file = client.open(full_path, "w")
             remote_file.write(data)
             remote_file.close()
 
     def get(self, relative_path, **kwargs):
         full_path = self._fullpath(relative_path)
         with sftp(self.collection) as client:
-            file_data = client.open(full_path, "rb")
+            file_data = client.open(full_path, "r")
             data = file_data.read()
             # TODO: shouldn't we close the file?
         return data


### PR DESCRIPTION
Previous code used the paramiko client open function with explicit binary mode.

But, the explicit binary mode is now ignored by python.
See the `open` function description into the paramiko documentation:
https://docs.paramiko.org/en/stable/api/sftp.html

```
The Python 'b' flag is ignored, since SSH treats all files as binary.
```

But in fact, depending of the SFTP server we have an `OSError`.

Then this PR remove the useless binary mode, and avoid to have errors.