### PR TITLE
[14.0] storage_file: add url_path (no CDN URL)

### DIFF
--- a/storage_file/models/storage_backend.py
+++ b/storage_file/models/storage_backend.py
@@ -141,17 +141,20 @@ class StorageBackend(models.Model):
         )
         return self.env["ir.config_parameter"].sudo().get_param(base_url_param)
 
-    def _get_url_for_file(self, storage_file):
+    def _get_url_for_file(self, storage_file, exclude_base_url=False):
         """Return final full URL for given file."""
         backend = self.sudo()
         if backend.served_by == "odoo":
             parts = [
-                self._get_base_url_from_param(),
+                self._get_base_url_from_param() if not exclude_base_url else "/",
                 "storage.file",
                 storage_file.slug,
             ]
         else:
-            parts = [backend.base_url_for_files or "", storage_file.relative_path or ""]
+            base_url = backend.base_url_for_files
+            if exclude_base_url:
+                base_url = base_url.replace(backend.base_url, "") or "/"
+            parts = [base_url, storage_file.relative_path or ""]
         return "/".join([x.rstrip("/") for x in parts if x])
 
     def _register_hook(self):

--- a/storage_file/tests/test_storage_file.py
+++ b/storage_file/tests/test_storage_file.py
@@ -113,6 +113,35 @@ class StorageFileCase(TransactionComponentCase):
             stfile.url, "https://foo.com/baz/test-of-my_file-{}.txt".format(stfile.id)
         )
 
+    def test_url_without_base_url(self):
+        stfile = self._create_storage_file()
+        # served by odoo
+        self.assertEqual(
+            stfile.url_path,
+            "/storage.file/test-of-my_file-{}.txt".format(stfile.id),
+        )
+        # served by external
+        stfile.backend_id.update(
+            {
+                "served_by": "external",
+                "base_url": "https://foo.com",
+                "directory_path": "baz",
+            }
+        )
+        stfile.invalidate_cache()
+        # path not included
+        self.assertEqual(
+            stfile.with_context(foo=1).url_path,
+            "/test-of-my_file-{}.txt".format(stfile.id),
+        )
+        # path included
+        stfile.backend_id.url_include_directory_path = True
+        stfile.invalidate_cache()
+        self.assertEqual(
+            stfile.url_path,
+            "/baz/test-of-my_file-{}.txt".format(stfile.id),
+        )
+
     def test_url_for_report(self):
         stfile = self._create_storage_file()
         params = self.env["ir.config_parameter"].sudo()

--- a/storage_media_product/models/product.py
+++ b/storage_media_product/models/product.py
@@ -62,6 +62,7 @@ class ProductMediaRelation(models.Model):
     )
     name = fields.Char(related="media_id.name", readonly=True)
     url = fields.Char(related="media_id.url", readonly=True)
+    url_path = fields.Char(related="media_id.url_path", readonly=True)
     media_type_id = fields.Many2one(related="media_id.media_type_id", readonly=True)
 
     @api.depends("media_id", "product_tmpl_id.attribute_line_ids.value_ids")


### PR DESCRIPTION
In some cases, is desirable to not have the CDN URL.
Examples:

- reduce payload of images metadata (the URL is the same for all of them)
- use same storage but different CDN URLs for different frontends