### PR TITLE
[14.0] storage_image_product: refactor and implement partial matching

### DIFF
--- a/storage_image_product/tests/test_product_image_relation.py
+++ b/storage_image_product/tests/test_product_image_relation.py
@@ -144,7 +144,7 @@ class ProductImageCase(StorageImageCommonCase):
         self.env["product.image.relation"].create(
             {
                 "product_tmpl_id": self.template.id,
-                "image_id": self.white_image.id,
+                "image_id": self.black_image.id,
                 "attribute_value_ids": [
                     (
                         6,
@@ -160,7 +160,42 @@ class ProductImageCase(StorageImageCommonCase):
         )
         # The variant should not take the only with the lowest sequence but
         # the one with same attributes
-        expected = ((self.white_image, self.product_b),)
+        expected = ((self.black_image, self.product_b),)
+        self._test_main_images_and_urls(expected)
+        expected = ((self.logo_image, self.product_c + self.product_a),)
+        self._test_main_images_and_urls(expected)
+
+    def test_main_image_attribute_partial_match(self):
+        """
+        Attach the image to the template and check the first image of the
+        variant is the one with same attributes
+        """
+        self.env["product.image.relation"].create(
+            {
+                "product_tmpl_id": self.template.id,
+                "image_id": self.logo_image.id,
+                "sequence": 1,
+            }
+        )
+        self.env["product.image.relation"].create(
+            {
+                "product_tmpl_id": self.template.id,
+                "image_id": self.black_image.id,
+                "attribute_value_ids": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.env.ref("product.product_attribute_value_4").id,
+                        ],
+                    )
+                ],
+                "sequence": 10,
+            }
+        )
+        # The variant should not take the only with the lowest sequence but
+        # the one with same attributes
+        expected = ((self.black_image, self.product_b),)
         self._test_main_images_and_urls(expected)
         expected = ((self.logo_image, self.product_c + self.product_a),)
         self._test_main_images_and_urls(expected)


### PR DESCRIPTION
When having an image compatible with the attribute of the variant
We want to use in priority the image with the most attribute matching
For example if you have product varianted in color and size, and you add a
black image, you want that all black variant use it


Note : in the test "def test_main_image_attribute(self):"  I have replaced the white image by the black image, I just change it to be consistent as the product was black.