### PR TITLE
[14.0][IMP] storage_media_product: Add optional description

### DIFF
--- a/storage_media_product/models/product.py
+++ b/storage_media_product/models/product.py
@@ -61,6 +61,7 @@ class ProductMediaRelation(models.Model):
         "storage.media.type", "Media Type", related="media_id.media_type_id"
     )
     name = fields.Char(related="media_id.name", readonly=True)
+    description = fields.Text()
     url = fields.Char(related="media_id.url", readonly=True)
     url_path = fields.Char(related="media_id.url_path", readonly=True)
     media_type_id = fields.Many2one(related="media_id.media_type_id", readonly=True)

--- a/storage_media_product/views/product.xml
+++ b/storage_media_product/views/product.xml
@@ -19,6 +19,7 @@
         <field name="arch" type="xml">
             <form string="Association">
                 <group>
+                    <field name="description" />
                     <field name="media_id" />
                     <field
                         name="available_attribute_value_ids"


### PR DESCRIPTION
Add description to Product Media Relation model because name is used for technical purposes.

CC @ForgeFlow  