### PR TITLE
[13.0][FIX] storabe_backend_ftp: fix file add

### DIFF
--- a/storage_backend_ftp/components/ftp_adapter.py
+++ b/storage_backend_ftp/components/ftp_adapter.py
@@ -96,6 +96,7 @@ class FTPStorageBackendAdapter(Component):
         with ftp(self.collection) as client:
             full_path = self._fullpath(relative_path)
             dirname = os.path.dirname(full_path)
+            filename = os.path.basename(full_path)
             if dirname:
                 try:
                     client.cwd(dirname)
@@ -106,7 +107,7 @@ class FTPStorageBackendAdapter(Component):
                         raise  # pragma: no cover
             with io.BytesIO(data) as tmp_file:
                 try:
-                    client.storbinary("STOR " + full_path, tmp_file)
+                    client.storbinary("STOR " + filename, tmp_file)
                 except ftplib.Error as e:
                     raise ValueError(repr(e))
                 except OSError as e:

--- a/storage_backend_ftp/components/ftp_adapter.py
+++ b/storage_backend_ftp/components/ftp_adapter.py
@@ -124,7 +124,8 @@ class FTPStorageBackendAdapter(Component):
         return data
 
     def list(self, relative_path):
-        full_path = self._fullpath(relative_path)
+        # The _fullpath(...) return a Posix object. We need a str
+        full_path = str(self._fullpath(relative_path))
         with ftp(self.collection) as client:
             try:
                 return client.nlst(full_path)

--- a/storage_backend_ftp/tests/test_ftp.py
+++ b/storage_backend_ftp/tests/test_ftp.py
@@ -59,9 +59,8 @@ class FtpCase(CommonCase, BackendStorageTestMixin):
             client.storbinary.assert_called()
             tmp_file.assert_called()
             tmp_file.assert_called_with(file_data)
-        client.storbinary.assert_called_with(
-            "STOR upload/fake/path", tmp_file().__enter__()
-        )
+        client.cwd.assert_called_with("upload/fake")
+        client.storbinary.assert_called_with("STOR path", tmp_file().__enter__())
 
     @mock.patch(FTP_LIB_PATH)
     def test_get(self, mocked_ftplib):


### PR DESCRIPTION
Due to `cwd(...)` just before the `storbinary(...)`, it's not correct to use the `full_path` to store the fiile.
And it raises an exception.