### PR TITLE
[13.0][IMP] storage_import_image_advanced: Use utf-8-sig decode to avoid Byte Order Mark character

### DIFF
--- a/storage_import_image_advanced/models/import_image.py
+++ b/storage_import_image_advanced/models/import_image.py
@@ -244,6 +244,9 @@ class ProductImageImportWizard(models.Model):
         )
         return report
 
+    def _get_file_path(self, line):
+        return line.get("file_path", False)
+
     def _get_product_identifier_field(self):
         """Override if you want to use another field as product identifier"""
         return "default_code"
@@ -293,7 +296,7 @@ class ProductImageImportWizard(models.Model):
 
         for prod in products:
             line = lines_by_code[prod[product_identifier_field]]
-            file_path = line["file_path"]
+            file_path = self._get_file_path(line)
             file_vals = self._prepare_file_values(file_path)
             if not file_vals:
                 report["file_not_found"].add(prod[product_identifier_field])

--- a/storage_import_image_advanced/models/import_image.py
+++ b/storage_import_image_advanced/models/import_image.py
@@ -187,7 +187,7 @@ class ProductImageImportWizard(models.Model):
             "file_path": self.csv_column_file_path,
         }
         with closing(io.BytesIO(self._read_csv())) as binary_file:
-            csv_file = (line.decode("utf8") for line in binary_file)
+            csv_file = (line.decode("utf-8-sig") for line in binary_file)
             reader = csv.DictReader(csv_file, delimiter=self.csv_delimiter)
             csv.field_size_limit(sys.maxsize)
             for row in reader:

--- a/storage_import_image_advanced/models/import_image.py
+++ b/storage_import_image_advanced/models/import_image.py
@@ -276,7 +276,13 @@ class ProductImageImportWizard(models.Model):
             _fields.append("product_template_attribute_value_ids")
         product_identifier_field = self._get_product_identifier_field()
         products = self.env[product_model].search_read(
-            [(product_identifier_field, "in", all_codes)], _fields
+            [
+                (product_identifier_field, "in", all_codes),
+                "|",
+                ("active", "=", True),
+                ("active", "=", False),
+            ],
+            _fields,
         )
         existing_by_code = {x[product_identifier_field]: x for x in products}
         report["missing"] = sorted(


### PR DESCRIPTION
When uploading some CSV that has BOM characters at the init of the file CSV Schema Incompatible error is show. Changing the decode to utf-8-sig solves the issue.

CC @ForgeFlow 