### PR TITLE
[15.0][IMP] boto3 version bump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # generated from manifests external_dependencies
-boto3<=1.15.17
+boto3<=1.15.18
 paramiko
 pyftpdlib
 python_slugify

--- a/storage_backend_s3/__manifest__.py
+++ b/storage_backend_s3/__manifest__.py
@@ -11,7 +11,7 @@
     "author": " Akretion, Odoo Community Association (OCA)",
     "license": "LGPL-3",
     "installable": True,
-    "external_dependencies": {"python": ["boto3<=1.15.17"]},
+    "external_dependencies": {"python": ["boto3<=1.15.18"]},
     "depends": ["storage_backend"],
     "data": ["views/backend_storage_view.xml"],
 }

--- a/storage_backend_s3/readme/ROADMAP.rst
+++ b/storage_backend_s3/readme/ROADMAP.rst
@@ -1,2 +1,2 @@
 There is an issue with the latest version of `boto3` and `urllib3`
-- boto3 needs to be `boto3<=1.15.17` related with https://github.com/OCA/storage/issues/67
+- boto3 needs to be `boto3<=1.15.18` related with https://github.com/OCA/storage/issues/67

--- a/storage_backend_s3/static/description/index.html
+++ b/storage_backend_s3/static/description/index.html
@@ -385,7 +385,7 @@ ul.auto-toc {
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#id1">Known issues / Roadmap</a></h1>
 <p>There is an issue with the latest version of <cite>boto3</cite> and <cite>urllib3</cite>
-- boto3 needs to be <cite>boto3&lt;=1.15.17</cite> related with <a class="reference external" href="https://github.com/OCA/storage/issues/67">https://github.com/OCA/storage/issues/67</a></p>
+- boto3 needs to be <cite>boto3&lt;=1.15.18</cite> related with <a class="reference external" href="https://github.com/OCA/storage/issues/67">https://github.com/OCA/storage/issues/67</a></p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>


### PR DESCRIPTION
After checking in detail, the problem (in https://github.com/OCA/storage/issues/67) comes with `boto3 >= 1.16.*`. Thus, let's put the latest `1.15.*` version.