### PR TITLE
[12.0][UPD] storage_backend: change development_status

### DIFF
--- a/storage_backend/__manifest__.py
+++ b/storage_backend/__manifest__.py
@@ -10,7 +10,7 @@
     "website": "https://www.github.com/OCA/storage",
     "author": " Akretion, Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "development_status": "Stable/Production",
+    "development_status": "Production/Stable",
     "installable": True,
     "depends": ["base", "component", "server_environment"],
     "data": [


### PR DESCRIPTION
This PR is for changing development status to match with the requirement of github CI. Some repos modules are depend on this module and CI is failed cause of `development_status`.

For reference : https://github.com/OCA/pylint-odoo/blob/0ac19f44eeee2466b290c2ce68f68afe985631c6/src/pylint_odoo/checkers/odoo_addons.py#L269

Related: https://github.com/OCA/server-tools/pull/2525#issuecomment-1383992548

@qrtl