### PR TITLE
[14.0][FIX] test-requirements: call correctly odoo_test_helper

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 vcrpy-unittest
 requests-mock
-odoo-test-helper
+odoo_test_helper


### PR DESCRIPTION
Used in storage_image_import and storage_thumbnail modules.