### PR TITLE
[13.0][FIX] storage_thumbnail: fix issue in compute.

### DIFF
--- a/storage_thumbnail/models/thumbnail_mixin.py
+++ b/storage_thumbnail/models/thumbnail_mixin.py
@@ -52,7 +52,7 @@ class ThumbnailMixing(models.AbstractModel):
         for rec in self:
             for scale in self._image_scale_mapping.keys():
                 fname = "thumb_%s_id" % scale
-                rec[fname] = self._get_thumb(scale_key=scale)
+                rec[fname] = rec._get_thumb(scale_key=scale)
 
     def _get_thumb(self, scale_key=None, scale=None):
         """Retrievet the first thumb matching given scale.


### PR DESCRIPTION
When adding multiple image at the same time, the thumbnail shown for each of them is the image of the first one.