### PR TITLE
[14.0][FIX] storage_backend_sftp: fix move_files

### DIFF
--- a/storage_backend_sftp/components/sftp_adapter.py
+++ b/storage_backend_sftp/components/sftp_adapter.py
@@ -102,10 +102,11 @@ class SFTPStorageBackendAdapter(Component):
 
     def move_files(self, files, destination_path):
         _logger.debug("mv %s %s", files, destination_path)
+        destination_full_path = self._fullpath(destination_path)
         with sftp(self.collection) as client:
             for sftp_file in files:
                 dest_file_path = os.path.join(
-                    destination_path, os.path.basename(sftp_file)
+                    destination_full_path, os.path.basename(sftp_file)
                 )
                 # Remove existing file at the destination path (an error is raised
                 # otherwise)
@@ -116,7 +117,8 @@ class SFTPStorageBackendAdapter(Component):
                 else:
                     client.unlink(dest_file_path)
                 # Move the file
-                client.rename(sftp_file, dest_file_path)
+                full_path = self._fullpath(sftp_file)
+                client.rename(full_path, dest_file_path)
 
     def delete(self, relative_path):
         full_path = self._fullpath(relative_path)

--- a/storage_backend_sftp/tests/test_sftp.py
+++ b/storage_backend_sftp/tests/test_sftp.py
@@ -102,16 +102,18 @@ class SftpCase(CommonCase, BackendStorageTestMixin):
         client.lstat.side_effect = FileNotFoundError()
         to_move = "move/from/path/myfile.txt"
         to_path = "move/to/path"
+        fullpath_from = self.backend.directory_path + "/" + to_move
+        fullpath_to = fullpath_from.replace("/from", "/to")
         self.backend.move_files([to_move], to_path)
         # no need to delete it
         client.unlink.assert_not_called()
         # rename gets called
-        client.rename.assert_called_with(to_move, to_move.replace("from", "to"))
+        client.rename.assert_called_with(fullpath_from, fullpath_to)
         # now try to override destination
         client.lstat.side_effect = None
         client.lstat.return_value = True
         self.backend.move_files([to_move], to_path)
         # client will delete it first
-        client.unlink.assert_called_with(to_move.replace("from", "to"))
+        client.unlink.assert_called_with(fullpath_to)
         # then move it
-        client.rename.assert_called_with(to_move, to_move.replace("from", "to"))
+        client.rename.assert_called_with(fullpath_from, fullpath_to)


### PR DESCRIPTION
This is an oversight. This method should take into account configuration `self.collection.directory_path` when moving files.