### PR TITLE
[16.0][FIX] fs_file: Invalidate cache on write

### DIFF
--- a/fs_file/readme/newsfragments/290.bugfix
+++ b/fs_file/readme/newsfragments/290.bugfix
@@ -1,0 +1,4 @@
+Ensure the cache is properly set when a new value is assigned to a FSFile field.
+If the field is stored the value to the cache must be a FSFileValue object
+linked to the attachment record used to store the file. Otherwise the value
+must be one given since it could be the result of a compute method.

--- a/fs_file/tests/test_fs_file.py
+++ b/fs_file/tests/test_fs_file.py
@@ -175,3 +175,17 @@ class TestFsFile(TransactionCase):
         # from the content
         value = FSFileValue(name="test", value=self.png_content)
         self.assertEqual(value.mimetype, "image/png")
+
+    def test_cache_invalidation(self):
+        """Test that the cache is invalidated when the FSFileValue is modified
+        When we assign a FSFileValue to a field, the value in the cache  must
+        be invalidated and the new value must be computed. This is required
+        because the FSFileValue from the cache should always be linked to the
+        attachment record used to store the file in the storage.
+        """
+        value = FSFileValue(name="test.png", value=self.create_content)
+        instance = self.env["test.model"].create({"fs_file": value})
+        self.assertNotEqual(instance.fs_file, value)
+        value = FSFileValue(name="test.png", value=self.write_content)
+        instance.write({"fs_file": value})
+        self.assertNotEqual(instance.fs_file, value)


### PR DESCRIPTION
When a new value is assigned to a stored FSFile field, the cache must be invalidated and not contain the given value. This is required since when you access a stored FSFile field, teh FSFileValue returned must be linked to the attachment used to store the file in the storage