### PR TITLE
[FIX] fs_attachment: add a few missing sudo to fs_attachment

### DIFF
--- a/fs_attachment/models/fs_storage.py
+++ b/fs_attachment/models/fs_storage.py
@@ -357,7 +357,7 @@ class FsStorage(models.Model):
         and the value is the limit in size below which attachments are kept in DB.
         0 means no limit.
         """
-        storage = self.get_by_code(code)
+        storage = self.sudo().get_by_code(code)
         if (
             storage
             and storage.use_as_default_for_attachments
@@ -369,17 +369,17 @@ class FsStorage(models.Model):
     @api.model
     @tools.ormcache("code")
     def _must_optimize_directory_path(self, code):
-        return self.get_by_code(code).optimizes_directory_path
+        return self.sudo().get_by_code(code).optimizes_directory_path
 
     @api.model
     @tools.ormcache("code")
     def _must_autovacuum_gc(self, code):
-        return self.get_by_code(code).autovacuum_gc
+        return self.sudo().get_by_code(code).autovacuum_gc
 
     @api.model
     @tools.ormcache("code")
     def _must_use_filename_obfuscation(self, code):
-        return self.get_by_code(code).use_filename_obfuscation
+        return self.sudo().get_by_code(code).use_filename_obfuscation
 
     @api.depends("base_url", "is_directory_path_in_url")
     def _compute_base_url_for_files(self):
@@ -401,7 +401,7 @@ class FsStorage(models.Model):
         :param attachment: an attachment record
         :return: the URL to access the attachment
         """
-        fs_storage = self.get_by_code(attachment.fs_storage_code)
+        fs_storage = self.sudo().get_by_code(attachment.fs_storage_code)
         if not fs_storage:
             return None
         base_url = fs_storage.base_url_for_files

--- a/fs_attachment/models/ir_attachment.py
+++ b/fs_attachment/models/ir_attachment.py
@@ -135,7 +135,7 @@ class IrAttachment(models.Model):
         for rec in self:
             if rec.store_fname:
                 code = rec.store_fname.partition("://")[0]
-                fs_storage = self.env["fs.storage"].get_by_code(code)
+                fs_storage = self.env["fs.storage"].sudo().get_by_code(code)
                 if fs_storage != rec.fs_storage_id:
                     rec.fs_storage_id = fs_storage
             elif rec.fs_storage_id:


### PR DESCRIPTION
fs.storage is protected as it contains credentials. It must be accessed sudo when needed for regular users manipulating ir.attachments.

I also add some sudo in compute functions. These are currently executed sudo anyway but this may change in the future.