### PR TITLE
[16.0][IMP] fs_storage: compute options protocol + refactor test class for re-use

### DIFF
--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -125,14 +125,13 @@ class FSStorage(models.Model):
     options_protocol = fields.Selection(
         string="Describes Protocol",
         selection="_get_options_protocol",
-        default="odoofs",
+        compute="_compute_protocol_descr",
         help="The protocol used to access the content of filesystem.\n"
         "This list is the one supported by the fsspec library (see "
         "https://filesystem-spec.readthedocs.io/en/latest). A filesystem protocol"
         "is added by default and refers to the odoo local filesystem.\n"
         "Pay attention that according to the protocol, some options must be"
         "provided through the options field.",
-        store=False,
     )
     options_properties = fields.Text(
         string="Available properties",
@@ -236,6 +235,7 @@ class FSStorage(models.Model):
     def _compute_protocol_descr(self) -> None:
         for rec in self:
             rec.protocol_descr = fsspec.get_filesystem_class(rec.protocol).__doc__
+            rec.options_protocol = rec.protocol
 
     @api.model
     def _get_options_protocol(self) -> list[tuple[str, str]]:

--- a/fs_storage/tests/__init__.py
+++ b/fs_storage/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import common
 from . import test_fs_storage

--- a/fs_storage/tests/common.py
+++ b/fs_storage/tests/common.py
@@ -1,0 +1,43 @@
+# Copyright 2023 ACSONE SA/NV (http://acsone.eu).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+import base64
+import shutil
+import tempfile
+from unittest import mock
+
+from odoo.tests.common import TransactionCase
+
+from ..models.fs_storage import FSStorage
+
+
+class TestFSStorageCase(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.backend: FSStorage = cls.env.ref("fs_storage.default_fs_storage")
+        cls.backend.json_options = {"target_options": {"auto_mkdir": "True"}}
+        cls.filedata = base64.b64encode(b"This is a simple file")
+        cls.filename = "test_file.txt"
+        cls.case_with_subdirectory = "subdirectory/here"
+        cls.demo_user = cls.env.ref("base.user_demo")
+
+    def setUp(self):
+        super().setUp()
+        mocked_backend = mock.patch.object(
+            self.backend.__class__, "_get_filesystem_storage_path"
+        )
+        mocked_get_filesystem_storage_path = mocked_backend.start()
+        tempdir = tempfile.mkdtemp()
+        mocked_get_filesystem_storage_path.return_value = tempdir
+
+        # pylint: disable=unused-variable
+        @self.addCleanup
+        def stop_mock():
+            mocked_backend.stop()
+            # recursively delete the tempdir
+            shutil.rmtree(tempdir)
+
+    def _create_file(self, backend: FSStorage, filename: str, filedata: str):
+        with backend.fs.open(filename, "wb") as f:
+            f.write(filedata)

--- a/fs_storage/tests/test_fs_storage.py
+++ b/fs_storage/tests/test_fs_storage.py
@@ -6,6 +6,7 @@ import tempfile
 import warnings
 from unittest import mock
 
+from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 from odoo.tools import mute_logger
 
@@ -151,3 +152,17 @@ class TestFSStorage(TransactionCase):
             .get("target_options")
             .get("odoo_storage_path"),
         )
+
+    def test_interface_values(self):
+        protocol = "file"  # should be available by default in the list of protocols
+        with Form(self.env["fs.storage"]) as new_storage:
+            new_storage.name = "Test storage"
+            new_storage.code = "code"
+            new_storage.protocol = protocol
+            self.assertEqual(new_storage.protocol, protocol)
+            # the options should follow the protocol
+            self.assertEqual(new_storage.options_protocol, protocol)
+            description = new_storage.protocol_descr
+            self.assertTrue("Interface to files on local storage" in description)
+        # this is still true after saving
+        self.assertEqual(new_storage.options_protocol, protocol)

--- a/fs_storage/tests/test_fs_storage.py
+++ b/fs_storage/tests/test_fs_storage.py
@@ -1,50 +1,14 @@
 # Copyright 2023 ACSONE SA/NV (http://acsone.eu).
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
-import base64
-import shutil
-import tempfile
 import warnings
-from unittest import mock
 
 from odoo.tests import Form
-from odoo.tests.common import TransactionCase
 from odoo.tools import mute_logger
 
-from ..models.fs_storage import FSStorage
+from .common import TestFSStorageCase
 
 
-class TestFSStorage(TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.backend: FSStorage = cls.env.ref("fs_storage.default_fs_storage")
-        cls.backend.json_options = {"target_options": {"auto_mkdir": "True"}}
-        cls.filedata = base64.b64encode(b"This is a simple file")
-        cls.filename = "test_file.txt"
-        cls.case_with_subdirectory = "subdirectory/here"
-        cls.demo_user = cls.env.ref("base.user_demo")
-
-    def setUp(self):
-        super().setUp()
-        mocked_backend = mock.patch.object(
-            self.backend.__class__, "_get_filesystem_storage_path"
-        )
-        mocked_get_filesystem_storage_path = mocked_backend.start()
-        tempdir = tempfile.mkdtemp()
-        mocked_get_filesystem_storage_path.return_value = tempdir
-
-        # pylint: disable=unused-variable
-        @self.addCleanup
-        def stop_mock():
-            mocked_backend.stop()
-            # recursively delete the tempdir
-            shutil.rmtree(tempdir)
-
-    def _create_file(self, backend: FSStorage, filename: str, filedata: str):
-        with backend.fs.open(filename, "wb") as f:
-            f.write(filedata)
-
+class TestFSStorage(TestFSStorageCase):
     @mute_logger("py.warnings")
     def _test_deprecated_setting_and_getting_data(self):
         # Check that the directory is empty


### PR DESCRIPTION
Before the change, reading the options protocol might not be in sync with the record protocol.
This is particularly the case if the record is save in the middle of editing as the value resets, which can be quite confusing.