### PR TITLE
[16.0][IMP] fs_product_multi_image: add labels on image fields

### DIFF
--- a/fs_product_multi_image/models/product_product.py
+++ b/fs_product_multi_image/models/product_product.py
@@ -25,9 +25,14 @@ class ProductProduct(models.Model):
         # Store it to improve perfs
         store=True,
     )
-    image = FSImage(related="main_image_id.image", readonly=True, store=False)
+    image = FSImage(
+        related="main_image_id.image", readonly=True, store=False, string="Public Image"
+    )
     image_medium = FSImage(
-        related="main_image_id.image_medium", readonly=True, store=False
+        related="main_image_id.image_medium",
+        readonly=True,
+        store=False,
+        string="Public Image Medium",
     )
 
     @api.depends(

--- a/fs_product_multi_image/models/product_template.py
+++ b/fs_product_multi_image/models/product_template.py
@@ -20,9 +20,14 @@ class ProductTemplate(models.Model):
         # Store it to improve perfs
         store=True,
     )
-    image = FSImage(related="main_image_id.image", readonly=True, store=False)
+    image = FSImage(
+        related="main_image_id.image", readonly=True, store=False, string="Public Image"
+    )
     image_medium = FSImage(
-        related="main_image_id.image_medium", readonly=True, store=False
+        related="main_image_id.image_medium",
+        readonly=True,
+        store=False,
+        string="Public Image Medium",
     )
 
     @api.depends("image_ids", "image_ids.sequence")


### PR DESCRIPTION
Otherwise fields `image` and `image_medium` have the same labels as standard odoo fields.