### PR TITLE
[16.0][FIX] image and image_medium labels to prevent odoo warning

### DIFF
--- a/fs_base_multi_image/models/fs_image_relation_mixin.py
+++ b/fs_base_multi_image/models/fs_image_relation_mixin.py
@@ -22,7 +22,7 @@ class FsImageRelationMixin(models.AbstractModel):
     specific_image = fs_fields.FSImage("Specific Image")
     # resized fields stored (as attachment) for performance
     specific_image_medium = fs_fields.FSImage(
-        "Specific Image 128",
+        "Specific Image (128)",
         related="specific_image",
         max_width=128,
         max_height=128,
@@ -31,11 +31,14 @@ class FsImageRelationMixin(models.AbstractModel):
     link_existing = fields.Boolean(default=False)
 
     image = fs_fields.FSImage(
-        "Image", compute="_compute_image", inverse="_inverse_image", store=False
+        "Image (original)",
+        compute="_compute_image",
+        inverse="_inverse_image",
+        store=False,
     )
     # resized fields stored (as attachment) for performance
     image_medium = fs_fields.FSImage(
-        "Image 128", compute="_compute_image_medium", store=False
+        "Image (128)", compute="_compute_image_medium", store=False
     )
 
     name = fields.Char(compute="_compute_name", store=True, index=True)

--- a/fs_base_multi_image/views/fs_image.xml
+++ b/fs_base_multi_image/views/fs_image.xml
@@ -15,7 +15,7 @@
                     </h1>
                     <group>
                         <group>
-                            <field name="image" />
+                            <field name="image" string="Image" />
                         </group>
                     </group>
                 </sheet>

--- a/fs_product_multi_image/views/product_template.xml
+++ b/fs_product_multi_image/views/product_template.xml
@@ -13,6 +13,7 @@
             <field name="image_1920" position="after">
                 <field
                     name="image"
+                    string="Image"
                     class="oe_avatar"
                     options="{'preview_image': 'image_medium', 'zoom': true}"
                 />


### PR DESCRIPTION
Prevent odoo warning during database initialization

- odoo.addons.base.models.ir_model: Two fields (image, image_1920) of product.template() have the same label: Image. [Modules: fs_product_multi_image and base] 
- odoo.addons.base.models.ir_model: Two fields (image_medium, image_128) of product.template() have the same label: Image 128. [Modules: fs_product_multi_image and base] 
- odoo.addons.base.models.ir_model: Two fields (image, image_1920) of product.product() have the same label: Image. [Modules: fs_product_multi_image and product] 
- odoo.addons.base.models.ir_model: Two fields (image_medium, image_128) of product.product() have the same label: Image 128. [Modules: fs_product_multi_image and product]