### PR TITLE
[FIX]Adapt the storbinary to handle FTP cwd

### DIFF
--- a/storage_backend_ftp/components/ftp_adapter.py
+++ b/storage_backend_ftp/components/ftp_adapter.py
@@ -100,6 +100,7 @@ class FTPStorageBackendAdapter(Component):
         with ftp(self.collection) as client:
             full_path = self._fullpath(relative_path)
             dirname = os.path.dirname(full_path)
+            basename = os.path.basename(full_path)
             if dirname:
                 try:
                     client.cwd(dirname)
@@ -110,7 +111,7 @@ class FTPStorageBackendAdapter(Component):
                         raise  # pragma: no cover
             with io.BytesIO(data) as tmp_file:
                 try:
-                    client.storbinary("STOR " + full_path, tmp_file)
+                    client.storbinary("STOR %s" % basename, tmp_file)
                 except ftplib.Error as e:
                     raise ValueError(repr(e))
                 except OSError as e:


### PR DESCRIPTION
When using "complex" directory path, the command CWD place the client in a folder. Then when submitting the file, fullpath no more exits relatively to the folder where the client is placed. In this case the full_path has to be replace by the basenam so that no more additionnal "relative path" will be added when trying to storebinary