### PR TITLE
[16.0] fs_storage: support SSH private keys authentication

### DIFF
--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -28,7 +28,7 @@ try:
     SSH_PKEYS = {
         "DSS": paramiko.DSSKey,
         "RSA": paramiko.RSAKey,
-        "ECDSA": paramiko.ECDSAKey,
+        "EC": paramiko.ECDSAKey,
         "OPENSSH": paramiko.Ed25519Key,
     }
 except ImportError:  # pragma: no cover

--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -382,7 +382,6 @@ class FSStorage(models.Model):
             pkey_file = io.StringIO(options["pkey"])
             pkey = self._get_ssh_private_key(
                 pkey_file,
-                pkey_type=options.pop("pkey_type", None),  # Remove extra parameter
                 passphrase=options.get("passphrase"),
             )
             options["pkey"] = pkey
@@ -413,10 +412,9 @@ class FSStorage(models.Model):
         if keytype:
             return keytype
 
-    def _get_ssh_private_key(self, pkey_file, pkey_type=None, passphrase=None):
+    def _get_ssh_private_key(self, pkey_file, passphrase=None):
         """Build the expected `paramiko.pkey.PKey` object."""
-        if not pkey_type:
-            pkey_type = self._detect_ssh_private_key_type(pkey_file)
+        pkey_type = self._detect_ssh_private_key_type(pkey_file)
         if not pkey_type:
             raise paramiko.SSHException("not a valid private key file")
         return SSH_PKEYS[pkey_type].from_private_key(pkey_file, password=passphrase)


### PR DESCRIPTION
SSH connections can now be done with private keys by setting the `pkey`+ `passphrase` options. Coupled with the `eval_options_from_env` this allows to set these ones from the environment, e.g:

`{"host": "sftp.example.net", "username": "odoo", "pkey": "$SSH_KEY", "passphrase": "$SSH_PASSPHRASE", "port": 22}`