### PR TITLE
[16.0][FIX] fs_product_multi_image: fix kanban view image display

### DIFF
--- a/fs_product_multi_image/views/fs_product_image.xml
+++ b/fs_product_multi_image/views/fs_product_image.xml
@@ -45,6 +45,7 @@
                 <div class="o_kanban_image me-1">
                     <img
                         t-att-src="kanban_image('fs.product.image', 'image_medium', record.id.raw_value)"
+                        t-if="record.id"
                         alt="Image"
                         class="o_image_64_contain"
                     />


### PR DESCRIPTION
This PR prevent to display the img tag in the common image relation kanban view to prevent an owl error.