### PR TITLE
[IMP] fs_storage: use fs.info() to check for the marker file

### DIFF
--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -272,9 +272,7 @@ class FSStorage(models.Model):
     def _check_connection(self, fs):
         marker_file_name = self._get_marker_file_name()
         try:
-            marker_file = fs.ls(marker_file_name, detail=False)
-            if not marker_file:
-                fs.touch(marker_file_name)
+            fs.info(marker_file_name)
         except FileNotFoundError:
             fs.touch(marker_file_name)
         return True


### PR DESCRIPTION
I'm facing an issue with https://github.com/OCA/storage/pull/320 and a SFTP storage:

```
  File "/odoo/external-src/storage/fs_storage/models/fs_storage.py", line 293, in fs
    self._check_connection(self.__fs)
  File "/odoo/external-src/storage/fs_storage/models/fs_storage.py", line 372, in _check_connection
    marker_file = fs.ls(marker_file_name, detail=False)
  File "/home/odoo/.local/lib/python3.10/site-packages/fsspec/implementations/sftp.py", line 127, in ls
    stats = [self._decode_stat(stat, path) for stat in self.ftp.listdir_iter(path)]
  File "/home/odoo/.local/lib/python3.10/site-packages/fsspec/implementations/sftp.py", line 127, in <listcomp>
    stats = [self._decode_stat(stat, path) for stat in self.ftp.listdir_iter(path)]
  File "/usr/local/lib/python3.10/site-packages/paramiko/sftp_client.py", line 278, in listdir_iter
    t, msg = self._request(CMD_OPENDIR, path)
  File "/usr/local/lib/python3.10/site-packages/paramiko/sftp_client.py", line 857, in _request
    return self._read_response(num)
  File "/usr/local/lib/python3.10/site-packages/paramiko/sftp_client.py", line 909, in _read_response
    self._convert_status(msg)
  File "/usr/local/lib/python3.10/site-packages/paramiko/sftp_client.py", line 942, in _convert_status
    raise IOError(text)
OSError: Not a directory
```

That's because of using `fs.ls()` to check for the existing of the marker file, see [here](https://github.com/OCA/storage/blob/16.0/fs_storage/models/fs_storage.py#L275). The sftp implementation of that method does not (yet) support files: see [here](https://github.com/fsspec/filesystem_spec/blob/master/fsspec/implementations/sftp.py#L125).

I understand that there was a rationale behind that choice, [here](https://github.com/OCA/storage/pull/320#issuecomment-1909540663).

But I think it's actually fine to use `fs.info()`, as underlying implementations override it with efficiency in mind:
- local, does [`os.stat`](https://github.com/fsspec/filesystem_spec/blob/master/fsspec/implementations/local.py#L72)
- sftp, does [`FTP stat`](https://github.com/fsspec/filesystem_spec/blob/master/fsspec/implementations/sftp.py#L96)
