### PR TITLE
[16.0][FIX] fs_storage: fix test connection when __fs slot is not initialized

### DIFF
--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -454,7 +454,8 @@ class FSStorage(models.Model):
 
     def action_test_config(self) -> None:
         try:
-            self._check_connection(self.__fs)
+            # pylint: disable=W0104
+            self.fs
             title = _("Connection Test Succeeded!")
             message = _("Everything seems properly set up!")
             msg_type = "success"

--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -292,6 +292,7 @@ class FSStorage(models.Model):
                 self._check_connection(self.__fs)
             except Exception as e:
                 self.__fs.clear_instance_cache()
+                self.__fs = None
                 raise e
         return self.__fs
 
@@ -454,6 +455,7 @@ class FSStorage(models.Model):
 
     def action_test_config(self) -> None:
         try:
+            # Accessing the property will check the connection
             # pylint: disable=W0104
             self.fs
             title = _("Connection Test Succeeded!")


### PR DESCRIPTION
When the __fs slot has not yet been initialized the test config method fails. As the check connection is called when accessing the property, we can simply access the property to test. Comes after https://github.com/OCA/storage/pull/320

CC @lmignon 