### PR TITLE
[IMP] fs_attachment: more robust pre_init_hook

### DIFF
--- a/fs_attachment/hooks.py
+++ b/fs_attachment/hooks.py
@@ -2,6 +2,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 import logging
 
+from odoo.tools.sql import column_exists
+
 _logger = logging.getLogger(__name__)
 
 
@@ -9,6 +11,8 @@ def pre_init_hook(cr):
     """Pre init hook."""
     # add columns for computed fields to avoid useless computation by the ORM
     # when installing the module
+    if column_exists(cr, "ir_attachment", "fs_storage_id"):
+        return  # columns already added; update probably failed partway
     _logger.info("Add columns for computed fields on ir_attachment")
     cr.execute(
         """


### PR DESCRIPTION
If say click-odoo-update fails partway, the columns are already created and the following tentative update fails because the columns exist.