### PR TITLE
16.0: issue with fs_attachment. Temporary hack for s3

### DIFF
--- a/fs_attachment/models/ir_attachment.py
+++ b/fs_attachment/models/ir_attachment.py
@@ -465,7 +465,9 @@ class IrAttachment(models.Model):
             # rename on S3 is a copy with an rm
             # and rename do not transfert acl correctly
             # so we need to add a chmod after the rename
-            if fs.fs.s3_additional_kwargs.get("acl"):
+            if hasattr(
+                fs.fs, "s3_additional_kwargs"
+            ) and fs.fs.s3_additional_kwargs.get("acl"):
                 fs.fs.chmod(
                     "/".join([fs.path, new_filename]),
                     acl=fs.fs.s3_additional_kwargs.get("acl"),

--- a/fs_attachment/models/ir_attachment.py
+++ b/fs_attachment/models/ir_attachment.py
@@ -460,6 +460,16 @@ class IrAttachment(models.Model):
             )
             fs.rename(filename, new_filename_with_path)
             attachment.fs_filename = new_filename
+
+            # TODO FIXME S3 hack
+            # rename on S3 is a copy with an rm
+            # and rename do not transfert acl correctly
+            # so we need to add a chmod after the rename
+            if fs.fs.s3_additional_kwargs.get("acl"):
+                fs.fs.chmod(
+                    "/".join([fs.path, new_filename]),
+                    acl=fs.fs.s3_additional_kwargs.get("acl"),
+                )
             # we need to update the store_fname with the new filename by
             # calling the write method of the field since the write method
             # of ir_attachment prevent normal write on store_fname


### PR DESCRIPTION
[DO NOT MERGE, it's an hack]

@lmignon @bealdav I have the following issue when using S3 bucket from scaleway.

In the case of scaleway when you when to make your image public you have to configure the acl "public-read" 
This work perfectly when uploading a file but when doing a rename, the lib will do a copy and rm. And the acl is not transferred.

The image are always private and never public.

This is an temporary hack, I share it to help other, but I think the issue is more in s3fs lib.


Note: I didn't had the time to do a real analyse but renaming have a cost for some provider (not big) https://stackoverflow.com/questions/33098211/does-rename-a-file-cost-money-on-s3. So maybe it's better to find a solution to directly push the file with the right name.



