### PR TITLE
[16.0] fs_attachment: sent the mimetype information for S3

### DIFF
--- a/fs_attachment/models/ir_attachment.py
+++ b/fs_attachment/models/ir_attachment.py
@@ -242,7 +242,9 @@ class IrAttachment(models.Model):
                     "db_datas": data,
                 }
                 return values
-        return super()._get_datas_related_values(data, mimetype)
+        return super(
+            IrAttachment, self.with_context(mimetype=mimetype)
+        )._get_datas_related_values(data, mimetype)
 
     ###########################################################
     # Odoo methods that we override to use the object storage #
@@ -381,6 +383,13 @@ class IrAttachment(models.Model):
             )
         return b""
 
+    def _storage_write_option(self, fs):
+        if hasattr(fs.fs, "s3"):
+            # For S3 storage the mimetype should be pass in the kwargs
+            return {"ContentType": self._context["mimetype"]}
+        else:
+            return {}
+
     @api.model
     def _storage_file_write(self, bin_data: bytes) -> str:
         """Write the file to the filesystem storage"""
@@ -391,7 +400,8 @@ class IrAttachment(models.Model):
         if not fs.exists(dirname):
             fs.makedirs(dirname)
         fname = f"{storage}://{path}"
-        with fs.open(path, "wb") as f:
+        kwargs = self._storage_write_option(fs)
+        with fs.open(path, "wb", **kwargs) as f:
             f.write(bin_data)
         self._fs_mark_for_gc(fname)
         return fname


### PR DESCRIPTION
When storing image on amazon s3, ovh or scaleway.
The minetype must be set in order to have the right mimetype when requesting the image publicly.

Note : when using the api put_file it will guess the mimetype automatically : https://github.com/fsspec/s3fs/blob/47ffcfad33f8c74974a1515cb266168ede6cf4b5/s3fs/core.py#L1176
