### PR TITLE
[16.0][FIX] fs_storage: remove default protocol

### DIFF
--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -84,7 +84,6 @@ class FSStorage(models.Model):
     protocol = fields.Selection(
         selection="_get_protocols",
         required=True,
-        default="odoofs",
         help="The protocol used to access the content of filesystem.\n"
         "This list is the one supported by the fsspec library (see "
         "https://filesystem-spec.readthedocs.io/en/latest). A filesystem protocol"


### PR DESCRIPTION
Since protocol is under server_environment control, it seems its default value takes priority over a value set in an XML record.

Since it does not really make much sense to create a storage backend without specifying the protocol, we remove the default value.
