### PR TITLE
[16.0][IMP] fs_attachment: No crash on missing file

### DIFF
--- a/fs_attachment/models/ir_attachment.py
+++ b/fs_attachment/models/ir_attachment.py
@@ -372,8 +372,14 @@ class IrAttachment(models.Model):
     def _storage_file_read(self, fname: str) -> bytes | None:
         """Read the file from the filesystem storage"""
         fs, _storage, fname = self._fs_parse_store_fname(fname)
-        with fs.open(fname, "rb") as f:
-            return f.read()
+        try:
+            with fs.open(fname, "rb") as f:
+                return f.read()
+        except IOError:
+            _logger.info(
+                "Error reading %s on storage %s", fname, _storage, exc_info=True
+            )
+        return b""
 
     @api.model
     def _storage_file_write(self, bin_data: bytes) -> str:

--- a/fs_attachment/readme/newsfragments/361.bugfix
+++ b/fs_attachment/readme/newsfragments/361.bugfix
@@ -1,0 +1,7 @@
+No crash o missign file.
+
+Prior to this change, Odoo was crashing as soon as access to a file stored into
+an external filesytem was not possible. This can lead to a complete system block.
+This change prevents this kind of blockage by ignoring access error to files
+stored into external system on read operations. These kind of errors are logged
+into the log files for traceability.

--- a/fs_attachment/static/description/index.html
+++ b/fs_attachment/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -753,7 +754,9 @@ Nans Lefebvre &lt;<a class="reference external" href="mailto:len&#64;lambdao.dev
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-17">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
When trying to get access to files stored into an external filesystem, don't crash if the files cannot be accessed. This is necessary to avoid blocking Odoo's operation if an external system is not accessible.