### PR TITLE
IMP fs_product_multi_image: allow to also display kanban in Images tab

### DIFF
--- a/fs_product_multi_image/models/product_template.py
+++ b/fs_product_multi_image/models/product_template.py
@@ -24,6 +24,11 @@ class ProductTemplate(models.Model):
     image_medium = FSImage(
         related="main_image_id.image_medium", readonly=True, store=False
     )
+    related_image_ids = fields.One2many(
+        comodel_name="fs.product.image",
+        related="image_ids",
+        help="Used to display 2 views of the same fields",
+    )
 
     @api.depends("image_ids", "image_ids.sequence")
     def _compute_main_image_id(self):

--- a/fs_product_multi_image/views/product_product.xml
+++ b/fs_product_multi_image/views/product_product.xml
@@ -33,7 +33,7 @@
                     <p class="oe_grey">
                         If you need to edit the images, do it from the product template.
                     </p>
-                    <field name="variant_image_ids" />
+                    <field name="variant_image_ids" mode="kanban" />
                 </page>
             </page>
         </field>

--- a/fs_product_multi_image/views/product_template.xml
+++ b/fs_product_multi_image/views/product_template.xml
@@ -34,6 +34,11 @@
                             <field name="specific_image" invisible="1" />
                         </tree>
                     </field>
+                    <field
+                        name="related_image_ids"
+                        mode="kanban"
+                        widget="storage_image_handle"
+                    />
                 </page>
             </page>
         </field>


### PR DESCRIPTION
We need to discuss the way we need/can display images.

Here is a dirty way to have kanban and drag and drop

![image](https://github.com/OCA/storage/assets/1853434/9c04fad9-5016-49c9-bc3c-7b38e2873a98)
