### PR TITLE
[16.0][FIX] fs_attachment: respect controller parameters for /web/content/

### DIFF
--- a/fs_attachment/models/ir_binary.py
+++ b/fs_attachment/models/ir_binary.py
@@ -44,6 +44,34 @@ class IrBinary(models.AbstractModel):
             return FsStream.from_fs_attachment(fs_attachment)
         return super()._record_to_stream(record, field_name)
 
+    def _get_stream_from(
+        self,
+        record,
+        field_name="raw",
+        filename=None,
+        filename_field="name",
+        mimetype=None,
+        default_mimetype="application/octet-stream",
+    ):
+        stream = super()._get_stream_from(
+            record,
+            field_name=field_name,
+            filename=filename,
+            filename_field=filename_field,
+            mimetype=mimetype,
+            default_mimetype=default_mimetype,
+        )
+
+        if stream.type == "fs":
+            if mimetype:
+                stream.mimetype = mimetype
+            if filename:
+                stream.download_name = filename
+            elif record and filename_field in record:
+                stream.download_name = record[filename_field] or stream.download_name
+
+        return stream
+
     def _get_image_stream_from(
         self,
         record,

--- a/fs_attachment/tests/test_stream.py
+++ b/fs_attachment/tests/test_stream.py
@@ -108,6 +108,17 @@ class TestStream(HttpCase):
             },
             assert_content=self.content,
         )
+        url = f"/web/content/{self.attachment_binary.id}/?filename=test2.txt&mimetype=text/csv"
+        self.assertDownload(
+            url,
+            headers={},
+            assert_status_code=200,
+            assert_headers={
+                "Content-Type": "text/csv; charset=utf-8",
+                "Content-Disposition": "inline; filename=test2.txt",
+            },
+            assert_content=self.content,
+        )
 
     def test_image_url(self):
         self.authenticate("admin", "admin")


### PR DESCRIPTION
when we craft a link like

`/web/content?model=my.model&filename_field=filename&field=binary_field&mimetype=mime.type&filename=myfile.name`

the parameters are ignored and the resulting download gets the generic (wrong) name/mimetype from the attachment of the binary field if it is of type `fs`. For filestore attachments, this happens in [`ir.binary#_get_stream_from`](https://github.com/OCA/OCB/blob/16.0/odoo/addons/base/models/ir_binary.py#L131), so I think we need to do the same thing for fs attachments. Otherwise, we can't really use this as drop-in replacement for storing binary fields in object storage.