### PR TITLE
[16.0][FIX] fs_storage: Change make_path_posix() to only 1 argument

### DIFF
--- a/fs_storage/__manifest__.py
+++ b/fs_storage/__manifest__.py
@@ -19,5 +19,5 @@
         "wizards/fs_test_connection.xml",
     ],
     "demo": ["demo/fs_storage.xml"],
-    "external_dependencies": {"python": ["fsspec"]},
+    "external_dependencies": {"python": ["fsspec>=2024.5.0"]},
 }

--- a/fs_storage/rooted_dir_file_system.py
+++ b/fs_storage/rooted_dir_file_system.py
@@ -25,7 +25,7 @@ class RootedDirFileSystem(DirFileSystem):
         # any relative paths.
         # Since the path separator is not always the same on all systems,
         # we need to normalize the path separator.
-        path_posix = os.path.normpath(make_path_posix(path, self.sep))
+        path_posix = os.path.normpath(make_path_posix(path))
         root_posix = os.path.normpath(make_path_posix(self.path))
         if not path_posix.startswith(root_posix):
             raise PermissionError(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # generated from manifests external_dependencies
-fsspec
+fsspec>=2024.5.0
 paramiko
 python_slugify


### PR DESCRIPTION
Change `make_path_posix()` to only 1 argument

Since https://github.com/fsspec/filesystem_spec/commit/da7754870bb9ab30c99fcd6dccdd39421f420691 it is necessary to set in `make_path_posix()` only 1 argument

@Tecnativa