### PR TITLE
[17.0][FIX] fs_storage: Change make_path_posix() to only 1 argument

### DIFF
--- a/fs_storage/__manifest__.py
+++ b/fs_storage/__manifest__.py
@@ -18,5 +18,5 @@
         "security/ir.model.access.csv",
     ],
     "demo": ["demo/fs_storage_demo.xml"],
-    "external_dependencies": {"python": ["fsspec"]},
+    "external_dependencies": {"python": ["fsspec>=2024.5.0"]},
 }

--- a/fs_storage/rooted_dir_file_system.py
+++ b/fs_storage/rooted_dir_file_system.py
@@ -25,7 +25,7 @@ class RootedDirFileSystem(DirFileSystem):
         # any relative paths.
         # Since the path separator is not always the same on all systems,
         # we need to normalize the path separator.
-        path_posix = os.path.normpath(make_path_posix(path, self.sep))
+        path_posix = os.path.normpath(make_path_posix(path))
         root_posix = os.path.normpath(make_path_posix(self.path))
         if not path_posix.startswith(root_posix):
             raise PermissionError(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # generated from manifests external_dependencies
-fsspec
+fsspec>=2024.5.0
 python_slugify


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/storage/pull/372

Change `make_path_posix()` to only 1 argument

Since https://github.com/fsspec/filesystem_spec/commit/da7754870bb9ab30c99fcd6dccdd39421f420691 it is necessary to set in `make_path_posix()` only 1 argument

@Tecnativa