### PR TITLE
[14.0][FIX] storage_backend_ftp: Fix the list method in ftp_adapter.py to return file names instead of full paths.

### DIFF
--- a/storage_backend_ftp/components/ftp_adapter.py
+++ b/storage_backend_ftp/components/ftp_adapter.py
@@ -130,7 +130,7 @@ class FTPStorageBackendAdapter(Component):
         full_path = self._fullpath(relative_path)
         with ftp(self.collection) as client:
             try:
-                return client.nlst(full_path)
+                return [os.path.basename(path) for path in client.nlst(full_path)]
             except IOError as e:
                 if e.errno == errno.ENOENT:
                     # The path do not exist return an empty list


### PR DESCRIPTION
This change aligns the behavior with s3_adapter. 
Detected when using edi_oca_storage, files were not being moved.