### PR TITLE
Replace author 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/fs_attachment/__manifest__.py
+++ b/fs_attachment/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 Camptocamp SA
+# Copyright 2017-2021 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 16.0.