### PR TITLE
[17.0][IMP] fs_storage: Allow setting eval_options_from_env in configuration file

### DIFF
--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -160,7 +160,12 @@ class FSStorage(models.Model):
 
     @property
     def _server_env_fields(self):
-        return {"protocol": {}, "options": {}, "directory_path": {}}
+        return {
+            "protocol": {},
+            "options": {},
+            "directory_path": {},
+            "eval_options_from_env": {},
+        }
 
     def write(self, vals):
         self.__fs = None


### PR DESCRIPTION
eval_options_from_env can not be set in the configuration file, which prevents using environment variables to avoid displaying the secret key in the UI.