### PR TITLE
[14.0][FIX] storage_thumbnail: always use slugified url_key

### DIFF
--- a/storage_thumbnail/models/thumbnail_mixin.py
+++ b/storage_thumbnail/models/thumbnail_mixin.py
@@ -101,6 +101,7 @@ class ThumbnailMixing(models.AbstractModel):
         return thumbnail
 
     def get_or_create_thumbnail(self, size_x, size_y, url_key=None):
+        url_key = self._get_url_key(url_key)
         thumbnail = self.get_existing_thumbnail(size_x, size_y, url_key=url_key)
         if not thumbnail and self.data:
             vals = self.env["storage.thumbnail"]._prepare_thumbnail(

--- a/storage_thumbnail/tests/test_thumbnail.py
+++ b/storage_thumbnail/tests/test_thumbnail.py
@@ -51,6 +51,18 @@ class TestStorageThumbnail(SavepointComponentCase):
         thumb.unlink()
         self.assertTrue(file_id.to_delete)
 
+    def test_image_get_or_create_thumbnail_no_duplicate(self):
+        # Ensure no duplicate is generated thanks to unique url_key
+        image = self._create_image()
+        self.assertTrue(image.url)
+        self.assertEqual(len(image.thumbnail_ids), 2)
+        thumb = image.thumb_small_id
+        thumb.url_key = "test"
+        existing_thumb = image.get_or_create_thumbnail(
+            thumb.size_x, thumb.size_y, url_key="TEST"
+        )
+        self.assertEqual(thumb, existing_thumb)
+
     def test_model(self):
         image = self._create_image()
         self.assertTrue(image.url)


### PR DESCRIPTION
Both for creating and searching thumbnails.

This avoid an infinite creation of thumbnails on images as soon as an `url_key` is provided.

This is a regression introduced by commit 197659721718024b520c2ff364bd97b15dfc0b4b

Ref. 4622