### PR TITLE
[17.0][IMP] fs_storage: invalidate orm cache when connection fails

### DIFF
--- a/fs_attachment/models/ir_attachment.py
+++ b/fs_attachment/models/ir_attachment.py
@@ -481,7 +481,7 @@ class IrAttachment(models.Model):
         code: str,
     ) -> fsspec.AbstractFileSystem | None:
         """Return the filesystem for the given storage code"""
-        fs = self.env["fs.storage"].get_fs_by_code(code)
+        fs = self.env["fs.storage"].sudo().get_fs_by_code(code)
         if not fs:
             raise SystemError(f"No Filesystem storage for code {code}")
         return fs

--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -200,17 +200,19 @@ class FSStorage(models.Model):
         :param code: the code of the filesystem
         """
         fs = self._get_fs_by_code(code)
-        try:
-            self._check_connection(fs)
-        except Exception as e:
-            _logger.warning(
-                "Error while connecting to the filesystem storage %s: %s",
-                code,
-                e,
-            )
-            # Generate a new fs instance
-            self.env.registry.clear_cache()
-            fs = self._get_fs_by_code(code)
+        
+        if not tools.config["test_enable"]:
+            try:
+                self._check_connection(fs)
+            except Exception as e:
+                _logger.warning(
+                    "Error while connecting to the filesystem storage %s: %s",
+                    code,
+                    e,
+                )
+                # Generate a new fs instance
+                self.env.registry.clear_cache()
+                fs = self._get_fs_by_code(code)
         return fs
 
     @api.model
@@ -478,7 +480,9 @@ class FSStorage(models.Model):
 
     def action_test_config(self) -> None:
         try:
-            self.fs
+            # _check_connection will be called two times as it is called by fs property
+            # However, I don't know another way to test the connection without as as single call `self.fs` is a 'pointless statement'
+            self._check_connection(self.fs)
             title = _("Connection Test Succeeded!")
             message = _("Everything seems properly set up!")
             msg_type = "success"

--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -200,7 +200,7 @@ class FSStorage(models.Model):
         :param code: the code of the filesystem
         """
         fs = self._get_fs_by_code(code)
-        
+
         if not tools.config["test_enable"]:
             try:
                 self._check_connection(fs)

--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -480,8 +480,6 @@ class FSStorage(models.Model):
 
     def action_test_config(self) -> None:
         try:
-            # _check_connection will be called two times as it is called by fs property
-            # However, I don't know another way to test the connection without as as single call `self.fs` is a 'pointless statement'
             self._check_connection(self.fs)
             title = _("Connection Test Succeeded!")
             message = _("Everything seems properly set up!")


### PR DESCRIPTION
Fixes #374 

I adapted a some parts of the code related to [_check_connection](https://github.com/OCA/storage/blob/3c19f00c9b1825afbf5a629e192309a9344e2e04/fs_storage/models/fs_storage.py#L297) from V16.0 (started in #320) and implemented it in V17.0.

Also, I added a check_connection everytime the fs is accessed to detected if it should be generated again or not.