### PR TITLE
[16.0][FIX] fs_storage: add missing sudo when creating FilsSystem

### DIFF
--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -306,7 +306,7 @@ class FSStorage(models.Model):
         """Get the fsspec filesystem for this backend."""
         self.ensure_one()
         if not self.__fs:
-            self.__fs = self._get_filesystem()
+            self.__fs = self.sudo()._get_filesystem()
         if not tools.config["test_enable"]:
             # Check whether we need to invalidate FS cache or not.
             # Use a marker file to limit the scope of the LS command for performance.


### PR DESCRIPTION
This is necessary for non admin users to access file systems, for instance for attachments.

This went unnoticed so far presumably because the filesystem is cached and likely accessed by the server during server bootstrap. I could confirm this by starting my dev server, accessing an attachment as a normal user (failed), then accessing an attachment as admin (succeeded), then as a normal user again (success).