### PR TITLE
[16.0][FIX] fs_attachment: Prevent recompute_urls from skipping records with res_field != False

### DIFF
--- a/fs_attachment/models/fs_storage.py
+++ b/fs_attachment/models/fs_storage.py
@@ -455,8 +455,18 @@ class FsStorage(models.Model):
         in staging are done in a different directory and will  not impact the
         production.
         """
-        attachments = self.env["ir.attachment"].search(
-            [("fs_storage_id", "in", self.ids)]
-        )
+        # The weird "res_field = False OR res_field != False" domain
+        # is required! It's because of an override of _search in ir.attachment
+        # which adds ('res_field', '=', False) when the domain does not
+        # contain 'res_field'.
+        # https://github.com/odoo/odoo/blob/9032617120138848c63b3cfa5d1913c5e5ad76db/
+        # odoo/addons/base/ir/ir_attachment.py#L344-L347
+        domain = [
+            ("fs_storage_id", "in", self.ids),
+            "|",
+            ("res_field", "=", False),
+            ("res_field", "!=", False),
+        ]
+        attachments = self.env["ir.attachment"].search(domain)
         attachments._compute_fs_url()
         attachments._compute_fs_url_path()


### PR DESCRIPTION
Currently `recompute_urls` will skip records which have a non-empty `res_field`, resulting in records with a valid `fs_storage_id` not being updated. The comment and fix were directly copied from [_force_storage_to_object_storage](https://github.com/OCA/storage/blob/ca197b1b2c12ec7e98915ead6b3d09b86a3a9efd/fs_attachment/models/ir_attachment.py#L719).