### PR TITLE
[16.0] storage_*: fix test import of mock

### DIFF
--- a/storage_backend/tests/common.py
+++ b/storage_backend/tests/common.py
@@ -3,8 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import base64
-
-import mock
+from unittest import mock
 
 from odoo.addons.component.tests.common import TransactionComponentCase
 

--- a/storage_backend_sftp/tests/test_sftp.py
+++ b/storage_backend_sftp/tests/test_sftp.py
@@ -11,8 +11,7 @@
 import errno
 import logging
 import os
-
-import mock
+from unittest import mock
 
 from odoo.addons.storage_backend.tests.common import BackendStorageTestMixin, CommonCase
 

--- a/storage_file/tests/test_storage_file.py
+++ b/storage_file/tests/test_storage_file.py
@@ -3,9 +3,8 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import base64
+from unittest import mock
 from urllib import parse
-
-import mock
 
 from odoo.exceptions import AccessError, UserError
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,1 @@
-mock
 odoo-test-helper


### PR DESCRIPTION
There's no need to depend on the additional lib mock.