### PR TITLE
[16.0][FIX] fs_product_multi_image: ensure to have a string when sorting variant images

### DIFF
--- a/fs_product_multi_image/models/product_product.py
+++ b/fs_product_multi_image/models/product_product.py
@@ -50,7 +50,7 @@ class ProductProduct(models.Model):
                 lambda i: i._match_variant(variant)
             )
             variant_image_ids = variant_image_ids.sorted(
-                key=lambda i: (i.sequence, i.name)
+                key=lambda i: (i.sequence, i.name or "")
             )
             variant.variant_image_ids = variant_image_ids
 


### PR DESCRIPTION
When adding multiple images on a product using the kanban view, an error was raised when saving the product. When the compute runs for the first time, names are ```False``` so it crashes.