### PR TITLE
[16.0][FIX] fs_attachment: fix fs_url computing

### DIFF
--- a/fs_attachment/README.rst
+++ b/fs_attachment/README.rst
@@ -423,6 +423,7 @@ Laurent Mignon <laurent.mignon@acsone.eu>
 Marie Lejeune <marie.lejeune@acsone.eu>
 Wolfgang Pichler <wpichler@callino.at>
 Nans Lefebvre <len@lambdao.dev>
+Mohamed Alkobrosli <alkobroslymohamed@gmail.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/fs_attachment/models/fs_storage.py
+++ b/fs_attachment/models/fs_storage.py
@@ -417,6 +417,13 @@ class FsStorage(models.Model):
         ):
             fs_filename = fs_filename.replace(fs_storage.directory_path, "")
         parts = [base_url, fs_filename]
+        if attachment.fs_storage_id:
+            if (
+                fs_storage.optimizes_directory_path
+                and not fs_storage.use_filename_obfuscation
+            ):
+                checksum = attachment.checksum
+                parts = [base_url, checksum[:2], checksum[2:4], fs_filename]
         return self._normalize_url("/".join(parts))
 
     @api.model

--- a/fs_attachment/readme/CONTRIBUTORS.rst
+++ b/fs_attachment/readme/CONTRIBUTORS.rst
@@ -12,3 +12,4 @@ Laurent Mignon <laurent.mignon@acsone.eu>
 Marie Lejeune <marie.lejeune@acsone.eu>
 Wolfgang Pichler <wpichler@callino.at>
 Nans Lefebvre <len@lambdao.dev>
+Mohamed Alkobrosli <alkobroslymohamed@gmail.com>

--- a/fs_attachment/static/description/index.html
+++ b/fs_attachment/static/description/index.html
@@ -763,7 +763,8 @@ Stephane Mangin &lt;<a class="reference external" href="mailto:stephane.mangin&#
 Laurent Mignon &lt;<a class="reference external" href="mailto:laurent.mignon&#64;acsone.eu">laurent.mignon&#64;acsone.eu</a>&gt;
 Marie Lejeune &lt;<a class="reference external" href="mailto:marie.lejeune&#64;acsone.eu">marie.lejeune&#64;acsone.eu</a>&gt;
 Wolfgang Pichler &lt;<a class="reference external" href="mailto:wpichler&#64;callino.at">wpichler&#64;callino.at</a>&gt;
-Nans Lefebvre &lt;<a class="reference external" href="mailto:len&#64;lambdao.dev">len&#64;lambdao.dev</a>&gt;</p>
+Nans Lefebvre &lt;<a class="reference external" href="mailto:len&#64;lambdao.dev">len&#64;lambdao.dev</a>&gt;
+Mohamed Alkobrosli &lt;<a class="reference external" href="mailto:alkobroslymohamed&#64;gmail.com">alkobroslymohamed&#64;gmail.com</a>&gt;</p>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-18">Maintainers</a></h2>


### PR DESCRIPTION
- Assuming that the optimized directory is checked and the directory path is not checked:
    - If the image is checked as obfuscated: 
        - then the fs_url refers to the image in its/dir1/dir2 directories that are named from checksum first 4 digits and this is fine.

    - But, if the image is not obfuscated:
        - then the "_get_url_for_attachment" method still computes the default method, forgetting that the fs_filename is the readable name and not obfuscated.
        
        I had to add the /dir1/dir2 to generate the correct URL

![Screenshot from 2024-10-10 20-42-24](https://github.com/user-attachments/assets/801dfb78-ebdb-4f57-b974-ce02324681eb)
![Screenshot from 2024-10-10 20-42-09](https://github.com/user-attachments/assets/971dd2cf-9bac-453e-b367-96cbc46e35ca)
![Screenshot from 2024-10-10 20-41-51](https://github.com/user-attachments/assets/4e58b5db-32da-45e8-96c2-53bec02134b5)

The module still needs testing and debugging, many tests failed and I see that store_fname is neglecting the directory path although it can be added like in my case.

I am looking forward to continuing debugging with assistance from the contributors.

Thanks All...