### PR TITLE
[FIX] fs_attachment: remove unwanted args

### DIFF
--- a/fs_attachment/README.rst
+++ b/fs_attachment/README.rst
@@ -423,6 +423,7 @@ Laurent Mignon <laurent.mignon@acsone.eu>
 Marie Lejeune <marie.lejeune@acsone.eu>
 Wolfgang Pichler <wpichler@callino.at>
 Nans Lefebvre <len@lambdao.dev>
+Mohamed Alkobrosli <alkobroslymohamed@gmail.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/fs_attachment/fs_stream.py
+++ b/fs_attachment/fs_stream.py
@@ -57,7 +57,6 @@ class FsStream(Stream):
             "max_age": STATIC_CACHE_LONG if immutable else self.max_age,
             "environ": request.httprequest.environ,
             "response_class": Response,
-            **send_file_kwargs,
         }
         use_x_sendfile = self._fs_use_x_sendfile
         # The file will be closed by werkzeug...

--- a/fs_attachment/readme/CONTRIBUTORS.rst
+++ b/fs_attachment/readme/CONTRIBUTORS.rst
@@ -12,3 +12,4 @@ Laurent Mignon <laurent.mignon@acsone.eu>
 Marie Lejeune <marie.lejeune@acsone.eu>
 Wolfgang Pichler <wpichler@callino.at>
 Nans Lefebvre <len@lambdao.dev>
+Mohamed Alkobrosli <alkobroslymohamed@gmail.com>

--- a/fs_attachment/static/description/index.html
+++ b/fs_attachment/static/description/index.html
@@ -763,7 +763,8 @@ Stephane Mangin &lt;<a class="reference external" href="mailto:stephane.mangin&#
 Laurent Mignon &lt;<a class="reference external" href="mailto:laurent.mignon&#64;acsone.eu">laurent.mignon&#64;acsone.eu</a>&gt;
 Marie Lejeune &lt;<a class="reference external" href="mailto:marie.lejeune&#64;acsone.eu">marie.lejeune&#64;acsone.eu</a>&gt;
 Wolfgang Pichler &lt;<a class="reference external" href="mailto:wpichler&#64;callino.at">wpichler&#64;callino.at</a>&gt;
-Nans Lefebvre &lt;<a class="reference external" href="mailto:len&#64;lambdao.dev">len&#64;lambdao.dev</a>&gt;</p>
+Nans Lefebvre &lt;<a class="reference external" href="mailto:len&#64;lambdao.dev">len&#64;lambdao.dev</a>&gt;
+Mohamed Alkobrosli &lt;<a class="reference external" href="mailto:alkobroslymohamed&#64;gmail.com">alkobroslymohamed&#64;gmail.com</a>&gt;</p>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-18">Maintainers</a></h2>


### PR DESCRIPTION
The module works fine if the Point of Sale module is not installed.
Once I install the POS module, the server returns a 500 error. 
By debugging the error, I found that an argument called **"content_security_policy"** was passed into the sendFile function, and it had a value of **None** as this argument is passed without being managed.

As long as this argument and other unmanaged arguments do NOT affect the behavior of the module or even the system, they have to be removed.

Only specified arguments are fine to pass to the sendFile function.

There are two references to using the patched sndFile function, but only one prototype is passing unmanaged arguments and the original behavior here imitated the prototype behavior which caused the error.

I have documented the error, the solution, and the two types of good behavior in the Odoo code.

![Screenshot from 2024-10-12 03-14-47](https://github.com/user-attachments/assets/bc5929b7-ed37-461e-83a7-8d6abddd1e53)

![Screenshot from 2024-10-12 03-20-33](https://github.com/user-attachments/assets/59954140-d11b-4870-a697-b624a1f299f8)

![Screenshot from 2024-10-12 03-21-27](https://github.com/user-attachments/assets/50181a5e-dc72-4a0f-b17b-736b7f38526d)

![Screenshot from 2024-10-25 23-45-46](https://github.com/user-attachments/assets/e2e7cc04-4268-46dc-a166-1bd2bfe1d73f)

![Screenshot from 2024-10-25 23-46-09](https://github.com/user-attachments/assets/0b9a70aa-c95f-43f5-a985-31b2c2d2b61e)

