### PR TITLE
[17.0][FIX] fs_attachment: Add CSP header for fs stream

### DIFF
--- a/fs_attachment/fs_stream.py
+++ b/fs_attachment/fs_stream.py
@@ -38,7 +38,13 @@ class FsStream(Stream):
                 return f.read()
         return super().read()
 
-    def get_response(self, as_attachment=None, immutable=None, **send_file_kwargs):
+    def get_response(
+        self,
+        as_attachment=None,
+        immutable=None,
+        content_security_policy="default-src 'none'",
+        **send_file_kwargs,
+    ):
         if self.type != "fs":
             return super().get_response(
                 as_attachment=as_attachment, immutable=immutable, **send_file_kwargs
@@ -79,6 +85,12 @@ class FsStream(Stream):
 
         if immutable and res.cache_control:
             res.cache_control["immutable"] = None
+
+        res.headers["X-Content-Type-Options"] = "nosniff"
+
+        if content_security_policy:
+            res.headers["Content-Security-Policy"] = content_security_policy
+
         return res
 
     @classmethod

--- a/fs_attachment/tests/test_stream.py
+++ b/fs_attachment/tests/test_stream.py
@@ -150,3 +150,16 @@ class TestStream(HttpCase):
             },
         )
         self.assertEqual(Image.open(io.BytesIO(res.content)).size, (64, 64))
+
+    def test_response_csp_header(self):
+        self.authenticate("admin", "admin")
+        url = f"/web/content/{self.attachment_binary.id}"
+        self.assertDownload(
+            url,
+            headers={},
+            assert_status_code=200,
+            assert_headers={
+                "X-Content-Type-Options": "nosniff",
+                "Content-Security-Policy": "default-src 'none'",
+            },
+        )


### PR DESCRIPTION
Odoo changed steam method for `Steam.get_response` to accept add CSP header from stream by default.
`FsStream.get_response` should update respect to this change.
Reference: 
- dev: https://github.com/odoo/odoo/pull/166532
- 17.0: https://github.com/odoo/odoo/pull/177090
- 16.0: https://github.com/odoo/odoo/pull/177090