### PR TITLE
[17.0][FIX] allow serving field attachment with fs stream

### DIFF
--- a/fs_attachment/tests/test_stream.py
+++ b/fs_attachment/tests/test_stream.py
@@ -1,5 +1,6 @@
 # Copyright 2023 ACSONE SA/NV (http://acsone.eu).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import base64
 import io
 import os
 import shutil
@@ -163,3 +164,31 @@ class TestStream(HttpCase):
                 "Content-Security-Policy": "default-src 'none'",
             },
         )
+
+    def test_serving_field_image(self):
+        self.authenticate("admin", "admin")
+        demo_partner = self.env.ref("base.partner_demo")
+        demo_partner.with_context(
+            storage_location=self.temp_backend.code,
+        ).write({"image_128": base64.encodebytes(self._create_image(128, 128))})
+        url = f"/web/image/{demo_partner._name}/{demo_partner.id}/image_128"
+        res = self.assertDownload(
+            url,
+            headers={},
+            assert_status_code=200,
+            assert_headers={
+                "Content-Type": "image/png",
+            },
+        )
+        self.assertEqual(Image.open(io.BytesIO(res.content)).size, (128, 128))
+
+        url = f"/web/image/{demo_partner._name}/{demo_partner.id}/avatar_128"
+        avatar_res = self.assertDownload(
+            url,
+            headers={},
+            assert_status_code=200,
+            assert_headers={
+                "Content-Type": "image/png",
+            },
+        )
+        self.assertEqual(Image.open(io.BytesIO(avatar_res.content)).size, (128, 128))


### PR DESCRIPTION
Current Issue: After the force_storage step is complete and the default file storage (fs.storage) is set, images are automatically migrated to use fs.attachment. However, image model fields such as image_128 and image_512 are not being served correctly by `ir.binary`. This PR aims to address this problem.

Proposed Solution: In the `IrBinary._get_image_stream_from` method, it is recommended to add a field attachment handler for binary fields when they are found to use fs.attachment. This should ensure that image fields are served properly.