### PR TITLE
[16.0] fs_storage: Allow setting eval_options_from_env in configuration file

### DIFF
--- a/.oca/oca-port/blacklist/fs_storage.json
+++ b/.oca/oca-port/blacklist/fs_storage.json
@@ -1,0 +1,5 @@
+{
+  "pull_requests": {
+    "OCA/storage#323": "migration PR"
+  }
+}

--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -176,7 +176,12 @@ class FSStorage(models.Model):
 
     @property
     def _server_env_fields(self):
-        return {"protocol": {}, "options": {}, "directory_path": {}}
+        return {
+            "protocol": {},
+            "options": {},
+            "directory_path": {},
+            "eval_options_from_env": {},
+        }
 
     def write(self, vals):
         self.__fs = None


### PR DESCRIPTION
backport of #382 from 17.0