### PR TITLE
[18.0][IMP] fs_storage: Allow setting eval_options_from_env in configuration file

### DIFF
--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -175,7 +175,12 @@ class FSStorage(models.Model):
 
     @property
     def _server_env_fields(self):
-        return {"protocol": {}, "options": {}, "directory_path": {}}
+        return {
+            "protocol": {},
+            "options": {},
+            "directory_path": {},
+            "eval_options_from_env": {},
+        }
 
     def write(self, vals):
         self.__fs = None


### PR DESCRIPTION
forward port of #382 from 17.0 