### PR TITLE
[16.0][FIX] fs_attachment: Implement retry mechanism for file read failures:

### DIFF
--- a/fs_attachment/models/fs_storage.py
+++ b/fs_attachment/models/fs_storage.py
@@ -108,6 +108,16 @@ class FsStorage(models.Model):
         compute="_compute_field_ids",
         inverse="_inverse_field_ids",
     )
+    read_retry_attempts = fields.Integer(
+        default=0,
+        help="Number of times to retry reading a file before failing. "
+        "It can apply to certain file storage backends like S3.",
+    )
+    read_retry_delay = fields.Float(
+        string="Retry Delay (seconds)",
+        default=0.0,
+        help="Seconds to wait between retries when reading a file.",
+    )
 
     @api.constrains("use_as_default_for_attachments")
     def _check_use_as_default_for_attachments(self):
@@ -501,3 +511,13 @@ class FsStorage(models.Model):
         attachments = self.env["ir.attachment"].search(domain)
         attachments._compute_fs_url()
         attachments._compute_fs_url_path()
+
+    @api.model
+    @tools.ormcache("code")
+    def get_read_retry_config(self, code):
+        """Return (retry_attempts, retry_delay) for a given storage code."""
+        storage = self.get_by_code(code)
+        return (
+            max(storage.read_retry_attempts, 0) if storage else 0,
+            max(storage.read_retry_delay, 0.0) if storage else 0.0,
+        )

--- a/fs_attachment/models/ir_attachment.py
+++ b/fs_attachment/models/ir_attachment.py
@@ -373,14 +373,29 @@ class IrAttachment(models.Model):
     @api.model
     def _storage_file_read(self, fname: str) -> bytes | None:
         """Read the file from the filesystem storage"""
-        fs, _storage, fname = self._fs_parse_store_fname(fname)
-        try:
-            with fs.open(fname, "rb") as f:
-                return f.read()
-        except IOError:
-            _logger.info(
-                "Error reading %s on storage %s", fname, _storage, exc_info=True
-            )
+        fs, storage_code, fname = self._fs_parse_store_fname(fname)
+
+        read_retry_attempts, read_retry_delay = (
+            self.env["fs.storage"].sudo().get_read_retry_config(storage_code)
+            if storage_code
+            else (0, 0.0)
+        )
+        for attempt in range(read_retry_attempts + 1):
+            try:
+                with fs.open(fname, "rb") as f:
+                    return f.read()
+            except FileNotFoundError:
+                _logger.info(
+                    "File not found %s on storage %s (attempt %d)",
+                    fname,
+                    storage_code,
+                    attempt + 1,
+                )
+                time.sleep(read_retry_delay)
+            except IOError:
+                _logger.info(
+                    "Error reading %s on storage %s", fname, storage_code, exc_info=True
+                )
         return b""
 
     def _storage_write_option(self, fs):

--- a/fs_attachment/views/fs_storage.xml
+++ b/fs_attachment/views/fs_storage.xml
@@ -36,6 +36,9 @@
                 <field name="is_directory_path_in_url" />
                 <field name="use_filename_obfuscation" />
                 <field name="use_x_sendfile_to_serve_internal_url" />
+                <separator string="Read Failure Parameters" />
+                <field name="read_retry_attempts" />
+                <field name="read_retry_delay" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Added a retry mechanism to `_storage_file_read` to handle intermittent `FileNotFoundError` issues. In real world this may happen when sending emails with heavy attachments on it. The file is attempted to be read but it is still not showing in S3. Tested with a mock file system that randomly raises `FileNotFoundError` to simulate real-world failures.