### PR TITLE
[18.0][FIX] fs_storage: fix `_ls_check_connection` when dealing with huge amount of files in root folder

### DIFF
--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -21,6 +21,8 @@ from odoo.addons.base_sparse_field.models.fields import Serialized
 
 _logger = logging.getLogger(__name__)
 
+LS_NON_EXISTING_FILE = ".NON_EXISTING_FILE"
+
 
 # TODO: useful for the whole OCA?
 def deprecated(reason):
@@ -296,7 +298,14 @@ class FSStorage(models.Model):
             fs.touch(marker_file_name)
 
     def _ls_check_connection(self, fs):
-        fs.ls("", detail=False)
+        # NOTE: run 'ls' on a non existing file to get better perf on FS
+        # having a huge amount of files in root folder.
+        # Getting a 'FileNotFoundError' means that the connection is working well.
+        try:
+            fs.ls(LS_NON_EXISTING_FILE, detail=False)
+        # pylint: disable=except-pass
+        except FileNotFoundError:
+            pass
 
     def _check_connection(self, fs, check_connection_method):
         if check_connection_method == "marker_file":


### PR DESCRIPTION
### Context

We tried to configure a storage on an `AzureBlobFileSystem` with 3.8+M of files located at the root directory.

### Issue

This storage is in read-only access, so we have to use the other option `ls` to check the connection. Issue is that the current `ls` on root folder will try to return too much file names, increasing the consumed memory, leading to a kill of the Odoo process.

### Proposed solution

Perform this `ls` on a non-existing file, which should then raise `FileNotFoundError` (to check if this exception is returned by all protocols?). If nothing is raised, that also means the connection is working (as before).

EDIT: Feedback, it is working well after 2 weeks