### PR TITLE
[FIX] fs_storage: Add a KeyError Exception

### DIFF
--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -240,7 +240,7 @@ class FSStorage(models.Model):
             try:
                 cls = fsspec.get_filesystem_class(p)
                 protocol.append((p, f"{p} ({cls.__name__})"))
-            except ImportError as e:
+            except Exception as e:
                 _logger.debug("Cannot load the protocol %s. Reason: %s", p, e)
         return protocol
 
@@ -274,7 +274,7 @@ class FSStorage(models.Model):
             try:
                 fsspec.get_filesystem_class(p)
                 protocol.append((p, p))
-            except ImportError as e:
+            except Exception as e:
                 _logger.debug("Cannot load the protocol %s. Reason: %s", p, e)
         return protocol
 


### PR DESCRIPTION
This is necessary in order to avoid issues in case fsspec added a new protocol and forget the error key

Without this change, edi-framework and storage are failing (and other tests might happen too).

The real error  is here:

https://github.com/fsspec/filesystem_spec/blame/50c5a2e161d85413e19e9e10d42de8b3cf56a921/fsspec/registry.py#L75-L77

An err key should be added, but it was forgotten. I created a PR in fsspec in order to fix it, but I think we can add this in order to avoid other errors.

https://github.com/fsspec/filesystem_spec/pull/1804

@lmignon @simahawk 

