### PR TITLE
[17.0][FIX] fs_storage: Add a generic Exception

### DIFF
--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -239,7 +239,7 @@ class FSStorage(models.Model):
             try:
                 cls = fsspec.get_filesystem_class(p)
                 protocol.append((p, f"{p} ({cls.__name__})"))
-            except ImportError as e:
+            except Exception as e:
                 _logger.debug("Cannot load the protocol %s. Reason: %s", p, e)
         return protocol
 
@@ -273,7 +273,7 @@ class FSStorage(models.Model):
             try:
                 fsspec.get_filesystem_class(p)
                 protocol.append((p, p))
-            except ImportError as e:
+            except Exception as e:
                 _logger.debug("Cannot load the protocol %s. Reason: %s", p, e)
         return protocol
 


### PR DESCRIPTION
This is necessary in order to avoid issues in case fsspec added a new protocol and forget the error key

FWP #457 