### PR TITLE
[18.0][FIX]: fs_storage fix _ls_check_connection enforce searching on dir

### DIFF
--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -21,7 +21,7 @@ from odoo.addons.base_sparse_field.models.fields import Serialized
 
 _logger = logging.getLogger(__name__)
 
-LS_NON_EXISTING_FILE = ".NON_EXISTING_FILE"
+LS_NON_EXISTING_FILE = "/.NON_EXISTING_FILE/a"
 
 
 # TODO: useful for the whole OCA?


### PR DESCRIPTION
The goal of the fix done in -> https://github.com/OCA/storage/pull/453 is to search for a non existing file.

It is not compatible as is with s3fs which will search recursively in all folders.
I'm enforcing a dir at the root of the bucket to ensure the search will not be done recursively.

Instead of using `fs.ls(LS_NON_EXISTING_FILE, detail=False)` , I'm currently wondering if we couldn't use `fs.exists(LS_NON_EXISTING_FILE)`
