### PR TITLE
[FIX] fs_attachment: attachment with newline in filename

### DIFF
--- a/fs_attachment/fs_stream.py
+++ b/fs_attachment/fs_stream.py
@@ -8,7 +8,7 @@ from odoo.tools import config
 from .models.ir_attachment import IrAttachment
 
 try:
-    from werkzeug.utils import send_file as _send_file
+    from werkzeug.utils import secure_filename, send_file as _send_file
 except ImportError:
     from odoo.tools._vendor.send_file import send_file as _send_file
 
@@ -53,10 +53,12 @@ class FsStream(Stream):
             as_attachment = self.as_attachment
         if immutable is None:
             immutable = self.immutable
+        # Sanitize the download_name before passing it
+        safe_download_name = secure_filename(self.download_name or "")
         send_file_kwargs = {
             "mimetype": self.mimetype,
             "as_attachment": as_attachment,
-            "download_name": self.download_name,
+            "download_name": safe_download_name,
             "conditional": self.conditional,
             "etag": self.etag,
             "last_modified": self.last_modified,

--- a/fs_attachment/tests/test_stream.py
+++ b/fs_attachment/tests/test_stream.py
@@ -189,3 +189,50 @@ class TestStream(HttpCase):
             },
         )
         self.assertEqual(Image.open(io.BytesIO(avatar_res.content)).size, (128, 128))
+
+    def test_image_url_name_with_newline(self):
+        """Test downloading a file with a newline in the name.
+
+        This test simulates the scenario that causes the Werkzeug error:
+        `ValueError: Detected newline in header value`.
+
+        It verifies that:
+        1. An `ir.attachment` record is created with a newline character
+           (`\n`) explicitly included in its `name` field ("tes\nt.png").
+        2. Accessing this attachment via the `/web/image/{attachment_id}` URL
+           succeeds with an HTTP 200 status code.
+        3. Crucially, the `Content-Disposition` header returned in the response
+           contains a *sanitized* filename ("tes_t.png"). The newline character
+           has been replaced (typically with an underscore by `secure_filename`).
+
+        This confirms that the filename sanitization implemented (likely in the
+        streaming logic, e.g., `FsStream.get_response` using `secure_filename`)
+        correctly processes the unsafe filename before passing it to Werkzeug,
+        thus preventing the original `ValueError` and ensuring safe header values.
+        """
+        attachment_image = (
+            self.env["ir.attachment"]
+            .with_context(
+                storage_location=self.temp_backend.code,
+                storage_file_path="test.png",
+            )
+            .create(
+                {"name": "tes\nt.png", "raw": self.image}
+            )  # newline in the filename
+        )
+        # Ensure the name IS stored with the newline before sanitization happens on download
+        self.assertIn("\n", attachment_image.name)
+
+        self.authenticate("admin", "admin")
+        url = f"/web/image/{attachment_image.id}"
+        self.assertDownload(
+            url,
+            headers={},
+            assert_status_code=200,
+            assert_headers={
+                "Content-Type": "image/png",
+                # Assert that the filename in the header IS sanitized
+                "Content-Disposition": "inline; filename=tes_t.png",
+            },
+            assert_content=self.image,
+        )


### PR DESCRIPTION
In case a file has a newline in its filename, during the download there's an error coming from werkzeug:
`ValueError: Detected newline in header value.  This is a potential security problem`

This is the full error:

```
2025-04-16 12:48:18,894 306 INFO odoo odoo.addons.fs_attachment.tests.test_stream: Starting TestStream.test_image_url_name_with_newline ... 
2025-04-16 12:48:19,361 306 INFO odoo odoo.addons.base.models.res_users: Login successful for db:odoo login:admin from n/a 
2025-04-16 12:48:19,369 306 INFO odoo odoo.addons.base.models.ir_http: Generating routing map for key 1 
2025-04-16 12:48:19,558 306 ERROR odoo odoo.http: Exception during request handling. 
Traceback (most recent call last):
  File "/opt/odoo/odoo/http.py", line 2071, in __call__
    response = request._serve_db()
  File "/opt/odoo/odoo/http.py", line 1658, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/opt/odoo/odoo/service/model.py", line 152, in retrying
    result = func()
  File "/opt/odoo/odoo/http.py", line 1686, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/odoo/http.py", line 1800, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/addons/website/models/ir_http.py", line 237, in _dispatch
    response = super()._dispatch(endpoint)
  File "/opt/odoo/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/odoo/http.py", line 734, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/addons/web/controllers/binary.py", line 170, in content_image
    return stream.get_response(**send_file_kwargs)
  File "/__w/storage/storage/fs_attachment/fs_stream.py", line 72, in get_response
    res = _send_file(f, **send_file_kwargs)
  File "/opt/odoo-venv/lib/python3.10/site-packages/werkzeug/utils.py", line 740, in send_file
    headers.set("Content-Disposition", value, **names)
  File "/opt/odoo-venv/lib/python3.10/site-packages/werkzeug/datastructures.py", line 1169, in set
    self._validate_value(_value)
  File "/opt/odoo-venv/lib/python3.10/site-packages/werkzeug/datastructures.py", line 1133, in _validate_value
    raise ValueError(
ValueError: Detected newline in header value.  This is a potential security problem
2025-04-16 12:48:19,560 306 INFO odoo werkzeug: 127.0.0.1 - - [16/Apr/2025 12:48:19] "GET /web/image/650 HTTP/1.1" 500 - 18 0.005 0.188
2025-04-16 12:48:19,562 306 INFO odoo odoo.addons.fs_attachment.tests.test_stream: ====================================================================== 
2025-04-16 12:48:19,562 306 ERROR odoo odoo.addons.fs_attachment.tests.test_stream: ERROR: TestStream.test_image_url_name_with_newline
Traceback (most recent call last):
  File "/__w/storage/storage/fs_attachment/tests/test_stream.py", line [228](https://github.com/OCA/storage/actions/runs/14493063934/job/40653822655?pr=468#step:8:229), in test_image_url_name_with_newline
    self.assertDownload(
  File "/__w/storage/storage/fs_attachment/tests/test_stream.py", line 87, in assertDownload
    res.raise_for_status()
  File "/opt/odoo-venv/lib/python3.10/site-packages/requests/models.py", line 943, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 500 Server Error: INTERNAL SERVER ERROR for url: http://127.0.0.1:8069/web/image/650
```