### PR TITLE
[18.0][IMP] fs_attachment: add {db} name options in directory path

### DIFF
--- a/fs_attachment/__manifest__.py
+++ b/fs_attachment/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Base Attachment Object Store",
     "summary": "Store attachments on external object store",
-    "version": "18.0.2.0.0",
+    "version": "18.1.0.0.0",
     "author": "Camptocamp, ACSONE SA/NV, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "development_status": "Beta",

--- a/fs_attachment/models/fs_storage.py
+++ b/fs_attachment/models/fs_storage.py
@@ -13,6 +13,19 @@ from .ir_attachment import IrAttachment
 class FsStorage(models.Model):
     _inherit = "fs.storage"
 
+    add_path_template = fields.Char(
+        string="Additonal Path Template",
+        help="""Additional path to the directory. Use {db} to include the database name in the path. e.g: 'prod/{db}'
+        This additional path is stored in the store_fname field. So if it is modified by the configuration (e.g. change of name of the database between production and staging) the attachments remain accessible.
+        Additionally, any modification of the attachment will use this new path and therefore will not change the production data.
+        """
+    )
+
+    add_path = fields.Char(
+        string="Computed Additonal Path",
+        compute="_compute_add_path",
+    )
+
     optimizes_directory_path = fields.Boolean(
         help="If checked, the directory path will be optimized to avoid "
         "too much files into the same directory. This options is used when the "
@@ -93,6 +106,7 @@ class FsStorage(models.Model):
         env_fields = super()._server_env_fields
         env_fields.update(
             {
+                "add_path_template": {},
                 "optimizes_directory_path": {},
                 "autovacuum_gc": {},
                 "base_url": {},
@@ -180,6 +194,15 @@ class FsStorage(models.Model):
                     )
                 ) from e
 
+    def _compute_add_path(self):
+        data = self.get_data_to_format()
+        for record in self:
+            template = record.add_path_template or ''
+            try:
+                record.add_path = template.format(**data)
+            except KeyError:
+                record.add_path = template  # fallback if the format is incorrect
+
     @api.model
     @tools.ormcache()
     def get_storage_code_for_attachments_fallback(self):
@@ -224,6 +247,11 @@ class FsStorage(models.Model):
         ):
             return const_eval(storage.force_db_for_default_attachment_rules)
         return {}
+
+    @api.model
+    @tools.ormcache("code")
+    def _computed_part_path(self, code):
+        return self.sudo().get_by_code(code).add_path
 
     @api.model
     @tools.ormcache("code")

--- a/fs_attachment/models/ir_attachment.py
+++ b/fs_attachment/models/ir_attachment.py
@@ -418,7 +418,8 @@ class IrAttachment(models.Model):
         if self.env["fs.storage"]._must_optimize_directory_path(storage_code):
             # Generate a unique directory path based on the file's hash
             key = os.path.join(key[:2], key[2:4], key)
-        # Generate a unique directory path based on the file's hash
+        # adds the variable part of the path to keep it in the fname. Essential when changing the name of the database, for example.
+        key = os.path.join(self.env["fs.storage"]._computed_part_path(storage_code), key)
         return key
 
     def _build_fs_filename(self):
@@ -701,6 +702,26 @@ class IrAttachment(models.Model):
             _logger.info("moving on the object storage from database")
             self.write({"datas": self.datas})
 
+    def _force_storage_to_db_for_special_fields_normmalized_domain(self, storage):
+        """Return a normalized domain for the given storage code.
+        Useful to find or count attachments that must be moved from the object storage to db.
+        """
+        return AND(
+            (
+                normalize_domain(
+                    [
+                        ("store_fname", "=like", f"{storage}://%"),
+                        # for res_field, see comment in
+                        # _force_storage_to_object_storage
+                        "|",
+                        ("res_field", "=", False),
+                        ("res_field", "!=", False),
+                    ]
+                ),
+                normalize_domain(self._store_in_db_instead_of_object_storage_domain()),
+            )
+        )
+
     @api.model
     def force_storage(self):
         if not self.env["res.users"].browse(self.env.uid)._is_admin():
@@ -727,31 +748,16 @@ class IrAttachment(models.Model):
         """
         storage = self._storage()
         if self._is_storage_disabled(storage):
-            return
+            return "Storage is disabled, cannot force storage to DB."
         if storage not in self._get_storage_codes():
-            return
-
-        domain = AND(
-            (
-                normalize_domain(
-                    [
-                        ("store_fname", "=like", f"{storage}://%"),
-                        # for res_field, see comment in
-                        # _force_storage_to_object_storage
-                        "|",
-                        ("res_field", "=", False),
-                        ("res_field", "!=", False),
-                    ]
-                ),
-                normalize_domain(self._store_in_db_instead_of_object_storage_domain()),
-            )
-        )
+            return "Storage is not configured, cannot force storage to DB."
+        domain = self._force_storage_to_db_for_special_fields_normmalized_domain(storage)
 
         with self._do_in_new_env(new_cr=new_cr) as new_env:
             model_env = new_env["ir.attachment"].with_context(prefetch_fields=False)
             attachment_ids = model_env.search(domain).ids
             if not attachment_ids:
-                return
+                return f"No special attachments to move from {storage} to DB"
             total = len(attachment_ids)
             start_time = time.time()
             _logger.info(
@@ -781,6 +787,7 @@ class IrAttachment(models.Model):
                         total,
                         time.time() - start_time,
                     )
+        return f"Moved {current}/{total} special attachments from {storage} to DB"
 
     @api.model
     def _force_storage_to_object_storage(self, new_cr=False):

--- a/fs_attachment/readme/USAGE.md
+++ b/fs_attachment/readme/USAGE.md
@@ -8,6 +8,22 @@ In addition to the common fields available to configure a storage,
 specifics fields are available under the section 'Attachment' to
 configure the way attachments will be stored in the filesystem.
 
+- `Additonal Path Template`: With this option, it is possible to use 
+  the `{db}` placeholder to automatically add the database name to the
+  path. This will make the path different for each database, which can
+  help organize documents when copying the database. The classic case
+  is copying a database from a production environment to a test environment.
+  You can use the `add_path_template` field to configure this as other
+  options. The information is stored at the store_fname level so attachments
+  will still be available even when a database is renamed. Old attachments
+  will be accessible from the old path.
+  ``` ini
+  [fs_storage.fsprod]
+  directory_path_template=my_bucket
+  add_path_template={db}
+  ```
+  => path = my_bucket/{db}
+
 - `Optimizes Directory Path`: This option is useful if you need to
   prevent having too many files in a single directory. It will create a
   directory structure based on the attachment's checksum (with 2 levels

--- a/fs_attachment/views/fs_storage.xml
+++ b/fs_attachment/views/fs_storage.xml
@@ -7,6 +7,9 @@
         <field name="model">fs.storage</field>
         <field name="inherit_id" ref="fs_storage.fs_storage_form_view" />
         <field name="arch" type="xml">
+            <field name="directory_path_template" position="after">
+                <field name="add_path_template" />
+            </field>
             <field name="options" position="after">
                 <separator string="Attachment" />
                 <field name="optimizes_directory_path" />

--- a/fs_storage/__manifest__.py
+++ b/fs_storage/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Filesystem Storage Backend",
     "summary": "Implement the concept of Storage with amazon S3, sftp...",
-    "version": "18.0.2.0.0",
+    "version": "18.1.0.0.0",
     "category": "FS Storage",
     "website": "https://github.com/OCA/storage",
     "author": " ACSONE SA/NV, Odoo Community Association (OCA)",

--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -127,7 +127,14 @@ class FSStorage(models.Model):
     )
 
     directory_path = fields.Char(
-        help="Relative path to the directory to store the file"
+        string="Computed Directory Path",
+        help="Relative path to the directory to store the file, as root path.",
+        compute="_compute_directory_path",
+    )
+
+    directory_path_template = fields.Char(
+        string="Directory Path Template",
+        help="Relative path to the directory to store the file as root path. Use {db} to include the database name in the path. e.g: 'prod/{db}'"
     )
 
     model_xmlids = fields.Char(
@@ -257,6 +264,22 @@ class FSStorage(models.Model):
                         % {"field": xmlid, "other_storage": other_storages[0].name}
                     )
 
+    def get_data_to_format(self):
+        """ Return the data to format the path. 
+        It is easy to add variables by overloading this method.
+        """
+        return {'db': self.env.cr.dbname}
+
+    #@api.depends('directory_path_template')
+    def _compute_directory_path(self):
+        data = self.get_data_to_format()
+        for record in self:
+            template = record.directory_path_template or ''
+            try:
+                record.directory_path = template.format(**data)
+            except KeyError:
+                record.directory_path = template  # fallback if the format is incorrect
+
     @api.model
     def _get_check_connection_method_selection(self):
         return [
@@ -269,7 +292,7 @@ class FSStorage(models.Model):
         return {
             "protocol": {},
             "options": {},
-            "directory_path": {},
+            "directory_path_template": {},
             "eval_options_from_env": {},
             "model_xmlids": {},
             "field_xmlids": {},

--- a/fs_storage/readme/USAGE.md
+++ b/fs_storage/readme/USAGE.md
@@ -42,7 +42,7 @@ follows:
 
 ``` python
 {
-    "directory_path": "/tmp/my_backend",
+    "directory_path_template": "/tmp/my_backend",
     "target_protocol": "odoofs",
     "target_options": {...},
 }
@@ -64,7 +64,7 @@ file as follows:
 [fs_storage.fsprod]
 protocol=s3
 options={"endpoint_url": "https://my_s3_server/", "key": "KEY", "secret": "SECRET"}
-directory_path=my_bucket
+directory_path_template=my_bucket
 ```
 
 To work, a storage.backend record must exist with the code fsprod into
@@ -73,7 +73,7 @@ for the following fields:
 
 - protocol
 - options
-- directory_path
+- directory_path_template
 
 ## Migration from storage_backend
 
@@ -98,3 +98,16 @@ version (V18) of the addon. You should use the methods of the
 fsspec.AbstractFileSystem class instead since they are more flexible and
 powerful. You can access the instance of the fsspec.AbstractFileSystem
 class using the fs property of a fs.storage record.
+
+## Directory Path Template
+It is possible to use the `{db}` placeholder to automatically add the database name to the path.
+This will make the path different for each database, which can help organize documents when 
+copying the database. The classic case is copying a database from a production environment 
+to a test environment.
+Be careful, this path change can prevent the original documents from being found. In the case of
+attachments, it may be preferable to use the `add_path_template` field so that the information
+is stored at the store_fname level.
+``` ini
+[fs_storage.fsprod]
+directory_path_template=my_bucket/{db}
+```

--- a/fs_storage/views/fs_storage_view.xml
+++ b/fs_storage/views/fs_storage_view.xml
@@ -34,7 +34,7 @@
                         <group>
                             <field name="code" />
                             <field name="protocol" />
-                            <field name="directory_path" />
+                            <field name="directory_path_template" />
                             <field name="eval_options_from_env" />
                             <field
                                 name="options"


### PR DESCRIPTION

Following PR #379, I'm revisiting the idea of ​​using a {db} placeholder to add the database name to the path, both from the configuration tools and from the form.
I haven't found a solution without impacting either the code (and therefore the modules dependent on fs_storage) or the way "fs_storage" is configured.

My proposal is to only impact the configuration by renaming the directory_path field to directory_path_template.
The initial field becomes a compute field, with no impact on the code. This is done in fs_storage module

I suggest adding add_path_template to store the information at the store_fname level if necessary (and it is in our case) so as not to lose access to the attachments. This is done in fs_attachment module.

It is easy to add more placeholders by overriding the single method used.

PS: I haven't touched the restriction on : "external_dependencies": {"python": ["fsspec>=2024.5.0"]},
although it seems to me to be less relevant now.

