### PR TITLE
[18.0][IMP] fs_storage: Makes the cache policy of fsspec client configurable

### DIFF
--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -189,6 +189,16 @@ class FSStorage(models.Model):
         "* List File : List all files from root directory",
     )
 
+    is_cacheable = fields.Boolean(
+        help="If True, once instantiated, the filesystem will be cached and reused.\n"
+        "By default, the filesystem is cacheable but in some cases, like "
+        "when using OAuth2 authentication, the filesystem cannot be cached "
+        "because it depends on the user and the token can change.\n"
+        "In this case, you can set this field to False to avoid caching the "
+        "filesystem.",
+        default=True,
+    )
+
     _sql_constraints = [
         (
             "code_uniq",
@@ -301,6 +311,23 @@ class FSStorage(models.Model):
         return res
 
     @api.model
+    @tools.ormcache("code")
+    def get_protocol_by_code(self, code):
+        record = self.get_by_code(code)
+        return record.protocol if record else None
+
+    @api.model
+    @tools.ormcache("code")
+    def _is_fs_cacheable(self, code):
+        """Return True if the filesystem is cacheable."""
+        # This method is used to check if the filesystem is cacheable.
+        # It is used to avoid caching filesystems that are not cacheable.
+        # For example, the msgd protocol is not cacheable because it uses
+        # OAuth2 authentication and the token can change.
+        fs_storage = self.get_by_code(code)
+        return fs_storage and fs_storage.is_cacheable
+
+    @api.model
     @tools.ormcache()
     def get_storage_codes(self):
         """Return the list of codes of the existing filesystems."""
@@ -308,15 +335,24 @@ class FSStorage(models.Model):
 
     @api.model
     @tools.ormcache("code")
-    def get_fs_by_code(self, code):
+    def _get_fs_by_code_from_cache(self, code):
+        return self.get_fs_by_code(code, force_no_cache=True)
+
+    @api.model
+    def get_fs_by_code(self, code, force_no_cache=False):
         """Return the filesystem associated to the given code.
 
         :param code: the code of the filesystem
         """
+
+        use_cache = not force_no_cache and self._is_fs_cacheable(code)
         fs = None
-        fs_storage = self.get_by_code(code)
-        if fs_storage:
-            fs = fs_storage.fs
+        if use_cache:
+            fs = self._get_fs_by_code_from_cache(code)
+        else:
+            fs_storage = self.get_by_code(code)
+            if fs_storage:
+                fs = fs_storage.fs
         return fs
 
     @api.model

--- a/fs_storage/views/fs_storage_view.xml
+++ b/fs_storage/views/fs_storage_view.xml
@@ -34,6 +34,7 @@
                         <group>
                             <field name="code" />
                             <field name="protocol" />
+                            <field name="is_cacheable" />
                             <field name="directory_path" />
                             <field name="eval_options_from_env" />
                             <field


### PR DESCRIPTION
On the fs.storage model you can now specify if the fsspec client must be cached into the ormcache once instanciated or not. By default, the filesystem is cacheable but in some cases, like when using OAuth2 authentication, the filesystem cannot be cached because it depends on the user and the token can change.