### PR TITLE
[FIX] fs_attachment: domain to store attachment in db was always [(1, '=', 1)]

### DIFF
--- a/fs_attachment/models/ir_attachment.py
+++ b/fs_attachment/models/ir_attachment.py
@@ -169,7 +169,8 @@ class IrAttachment(models.Model):
             part = [("mimetype", "=like", f"{mimetype_key}%")]
             if limit:
                 part = AND([part, [("file_size", "<=", limit)]])
-            domain = OR([domain, part])
+            # OR simplifies to [(1, '=', 1)] if a domain being OR'ed is empty
+            domain = OR([domain, part]) if domain else part
         return domain
 
     def _store_in_db_instead_of_object_storage(self, data, mimetype):

--- a/fs_attachment/tests/test_fs_attachment.py
+++ b/fs_attachment/tests/test_fs_attachment.py
@@ -469,3 +469,21 @@ class TestFSAttachment(TestFSAttachmentCommon):
         attachment.write({"name": "file2.txt"})
         self.assertTrue(attachment.fs_filename.startswith("file2-"))
         self.assertTrue(attachment.fs_filename.endswith(".txt"))
+
+    def test_store_in_db_instead_of_object_storage_domain(self):
+        IrAttachment = self.env["ir.attachment"]
+        self.patch(
+            type(IrAttachment),
+            "_get_storage_force_db_config",
+            lambda self: {"text/plain": 0, "image/png": 100},
+        )
+        self.assertEqual(
+            self.env["ir.attachment"]._store_in_db_instead_of_object_storage_domain(),
+            [
+                "|",
+                ("mimetype", "=like", "text/plain%"),
+                "&",
+                ("mimetype", "=like", "image/png%"),
+                ("file_size", "<=", 100),
+            ],
+        )


### PR DESCRIPTION
This is due to domain simplification algorithm introduced recently in Odoo.