### PR TITLE
[14.0][FIX] do not prefetch data on image, file.

### DIFF
--- a/storage_file/models/storage_file.py
+++ b/storage_file/models/storage_file.py
@@ -81,6 +81,11 @@ class StorageFile(models.Model):
         )
     ]
 
+    def _in_cache_without(self, field, limit=models.PREFETCH_MAX):
+        if field.name == "data":
+            limit = 1
+        return super()._in_cache_without(field, limit=limit)
+
     def write(self, vals):
         if "data" in vals:
             for record in self:

--- a/storage_image/models/storage_image.py
+++ b/storage_image/models/storage_image.py
@@ -30,6 +30,11 @@ class StorageImage(models.Model):
     alt_name = fields.Char(string="Alt Image name")
     file_id = fields.Many2one("storage.file", "File", required=True, ondelete="cascade")
 
+    def _in_cache_without(self, field, limit=models.PREFETCH_MAX):
+        if field.name == "data":
+            limit = 1
+        return super()._in_cache_without(field, limit=limit)
+
     @api.onchange("name")
     def onchange_name(self):
         for record in self:

--- a/storage_thumbnail/models/storage_thumbnail.py
+++ b/storage_thumbnail/models/storage_thumbnail.py
@@ -28,6 +28,11 @@ class StorageThumbnail(models.Model):
     res_model = fields.Char(readonly=False, index=True)
     res_id = fields.Integer(readonly=False, index=True)
 
+    def _in_cache_without(self, field, limit=models.PREFETCH_MAX):
+        if field.name == "data":
+            limit = 1
+        return super()._in_cache_without(field, limit=limit)
+
     def _prepare_thumbnail(self, image, size_x, size_y, url_key):
         image_resize_format = (
             self.env["ir.config_parameter"]


### PR DESCRIPTION
When generating image thumbnail, odoo is going to prefetch all the data of all image.
This is costly and useless as the get_or_create_thumbnail is going to invalidate all the cache.


See the code here: https://github.com/OCA/storage/blob/ebcd5c84d7754c107d4d6c84bbfb583724d48a62/storage_thumbnail/models/thumbnail_mixin.py#L103


Note odoo code is prefetching all record when processing computed field 
https://github.com/odoo/odoo/blob/14.0/odoo/fields.py#L1041



