### PR TITLE
[18.0] storage_image_product: fix kanban image visibility

### DIFF
--- a/storage_image_product/views/product_template.xml
+++ b/storage_image_product/views/product_template.xml
@@ -33,6 +33,7 @@
             <xpath expr="//aside/field[@name='image_128']" position="attributes">
                 <attribute name="name">image_small_url</attribute>
                 <attribute name="widget">image_url</attribute>
+                <attribute name="invisible">not image_small_url</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
The invisible attribute is not image_128 in odoo core. If we don't override it, our image won't be displayed.