### PR TITLE
[18.0] storage_image_product: ease test setup for other modules

### DIFF
--- a/storage_image_product/tests/common.py
+++ b/storage_image_product/tests/common.py
@@ -8,7 +8,7 @@ import os
 from odoo.addons.component.tests.common import TransactionComponentCase
 
 
-class ProductImageCommonCase(TransactionComponentCase):
+class ProductImageCaseMixin:
     @staticmethod
     def _get_file_content(name, base_path=None, as_binary=False):
         path = base_path or os.path.dirname(os.path.abspath(__file__))
@@ -25,8 +25,7 @@ class ProductImageCommonCase(TransactionComponentCase):
         )
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def _setup_base_image_data(cls):
         cls.template = cls.env.ref("product.product_product_4_product_template")
         cls.product_a = cls.env.ref("product.product_product_4")
         cls.product_b = cls.env.ref("product.product_product_4b")
@@ -34,3 +33,10 @@ class ProductImageCommonCase(TransactionComponentCase):
         cls.logo_image = cls._create_storage_image("logo-image.jpg")
         cls.white_image = cls._create_storage_image("white-image.jpg")
         cls.black_image = cls._create_storage_image("black-image.jpg")
+
+
+class ProductImageCommonCase(TransactionComponentCase, ProductImageCaseMixin):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._setup_base_image_data()


### PR DESCRIPTION
Having a mixin class allows to run the setup of the base data explicitly where needed especially when you have test classes with multiple inheritances.

After the Odoo tests apocalypse we cannot rely anymore on running Klass.setUpClass() w/o tons of attributes warning. Now you can inherit the mixin and do the setup properly.