### PR TITLE
[18.0][IMP] fs_attachment: enhance stream download name handling based on mimetype

### DIFF
--- a/fs_attachment/models/ir_binary.py
+++ b/fs_attachment/models/ir_binary.py
@@ -1,12 +1,14 @@
 # Copyright 2023 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 import logging
+from mimetypes import guess_extension
 
 import werkzeug.http
 
 from odoo import models
 from odoo.http import request
 from odoo.tools.image import image_process
+from odoo.tools.mimetypes import get_extension
 
 from ..fs_stream import FsStream
 
@@ -72,6 +74,12 @@ class IrBinary(models.AbstractModel):
                 stream.download_name = filename
             elif record and filename_field in record:
                 stream.download_name = record[filename_field] or stream.download_name
+
+        if (
+            not get_extension(stream.download_name)
+            and stream.mimetype != "application/octet-stream"
+        ):
+            stream.download_name += guess_extension(stream.mimetype) or ""
 
         return stream
 


### PR DESCRIPTION
Fixes missing file extension when downloading with Microsoft Edge.

<img width="832" height="462" alt="image" src="https://github.com/user-attachments/assets/b00fe105-2160-4dd8-af96-8da35da4838c" />

Alligns with: https://github.com/odoo/odoo/blob/18.0/odoo/addons/base/models/ir_binary.py#L148-L149