### PR TITLE
[16.0] [FIX] fs_attachment: prevent 416 on Range requests with X-Accel-Redirect

### DIFF
--- a/fs_attachment/fs_stream.py
+++ b/fs_attachment/fs_stream.py
@@ -74,6 +74,14 @@ class FsStream(Stream):
         else:
             x_sendfile_path = self.fs_attachment._get_x_sendfile_path()
             send_file_kwargs["use_x_sendfile"] = True
+
+            # Strip Range header from environ: _send_file("") stats the cwd
+            # (size=4096 on Linux), causing werkzeug to reject Range requests
+            # with 416. S3/nginx handle Range natively via X-Accel-Redirect.
+            environ = dict(send_file_kwargs["environ"])
+            environ.pop("HTTP_RANGE", None)
+            send_file_kwargs["environ"] = environ
+
             res = _send_file("", **send_file_kwargs)
             # nginx specific headers
             res.headers["X-Accel-Redirect"] = x_sendfile_path


### PR DESCRIPTION
**Currently range requests are not working (for example in preview videos in Discuss application using firefox) early terminated with HTTP error 416**

Media resource baseurl/mail/channel/340/attachment/56318 could not be decoded, error: Error Code: NS_ERROR_DOM_MEDIA_RANGE_ERR (0x806e0069)
Details: Result<already_AddRefed<MediaRawData>, MediaResult> __cdecl mozilla::SampleIterator::GetNext(void): Sample data read failed

Why fs_attachment and not fs_attachment_s3?

_fs_use_x_sendfile() checks fs_storage_id.use_x_sendfile_to_serve_internal_url — this is a generic flag on any fs.storage record, not S3-specific. The _send_file("") bug triggers for every backend (S3, local filesystem, SFTP, whatever) that has this checkbox enabled.

The flow is:

FsStream.get_response() in fs_attachment calls _send_file("") -> bug is here
fs_attachment_s3 only extends how the redirect URL is built, not the response creation
So fs_attachment is the correct place. Moving it to fs_attachment_s3 would leave the bug open for any other storage using X-Accel-Redirect.