### PR TITLE
[18.0][IMP] fs_attachment: improve attachment storage handling of files without body (size=0)

### DIFF
--- a/fs_attachment/models/ir_attachment.py
+++ b/fs_attachment/models/ir_attachment.py
@@ -253,6 +253,18 @@ class IrAttachment(models.Model):
             storage = super()._storage()
         return storage
 
+    @api.depends("store_fname", "db_datas")
+    def _compute_raw(self):
+        """Always expose raw payload as bytes.
+
+        Some callers (e.g. account EDI helpers) slice the value returned by
+        ``raw`` and crash when it is ``False`` for 0-byte attachments.
+        """
+        res = super()._compute_raw()
+        false_attachments = self.filtered(lambda att: not att.raw)
+        false_attachments.raw = b""
+        return res
+
     @api.model_create_multi
     def create(self, vals_list):
         """
@@ -697,9 +709,10 @@ class IrAttachment(models.Model):
         self.ensure_one()
         _logger.info("inspecting attachment %s (%d)", self.name, self.id)
         fname = self.store_fname
-        storage = fname.partition("://")[0]
-        if self._is_storage_disabled(storage):
-            fname = False
+        if fname:
+            storage = fname.partition("://")[0]
+            if self._is_storage_disabled(storage):
+                fname = False
         if fname:
             # migrating from filesystem filestore
             # or from the old 'store_fname' without the bucket name

--- a/fs_attachment/tests/test_fs_attachment.py
+++ b/fs_attachment/tests/test_fs_attachment.py
@@ -75,6 +75,12 @@ class TestFSAttachment(TestFSAttachmentCommon):
         with attachment.open("rb") as f:
             self.assertEqual(f.read(), new_content)
 
+    def test_create_attachment_with_no_payload_has_bytes_raw(self):
+        attachment = self.ir_attachment_model.create({"name": "empty.txt"})
+
+        self.assertEqual(attachment.raw, b"")
+        self.assertEqual(attachment.file_size, 0)
+
     def test_open_attachment_in_db(self):
         self.env["ir.config_parameter"].sudo().set_param("ir_attachment.location", "db")
         content = b"This is a test attachment in db"


### PR DESCRIPTION
Uploading an 0kb documents runs into this error. This also affects incoming mails with e.g. tracking images (helpdesk/vendorbills).

```
RPC_ERROR

Odoo Server Error

Occured on c4a8.odoo.com on model account.journal on 2026-04-21 13:36:19 GMT

Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/http.py", line 2167, in _transactioning
    return service_model.retrying(func, env=self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/service/model.py", line 157, in retrying
    result = func()
             ^^^^^^
  File "/home/odoo/src/odoo/odoo/http.py", line 2134, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/http.py", line 2382, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_http.py", line 333, in _dispatch
    result = endpoint(**request.params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/web/controllers/dataset.py", line 36, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/api.py", line 535, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/enterprise/documents_account/models/account_journal.py", line 13, in create_document_from_attachment
    action = super().create_document_from_attachment(attachment_ids)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/enterprise/account_bank_statement_import/models/account_journal.py", line 31, in create_document_from_attachment
    return super().create_document_from_attachment(attachment_ids)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/account/models/account_journal.py", line 988, in create_document_from_attachment
    invoices = self._create_document_from_attachment(attachment_ids)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/account/models/account_journal.py", line 970, in _create_document_from_attachment
    invoice.with_context(skip_is_manually_modified=True)._extend_with_attachments(attachment, new=True)
  File "/home/odoo/src/odoo/addons/account/models/account_move.py", line 4344, in _extend_with_attachments
    file_data_list = attachments._unwrap_edi_attachments()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/account/models/ir_attachment.py", line 159, in _unwrap_edi_attachments
    if supported_format['check'](attachment):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/account/models/ir_attachment.py", line 120, in is_xml
    is_text_plain_xml = 'text/plain' in attachment.mimetype and (guess_mimetype(attachment.raw).endswith('/xml') or attachment.name.endswith('.xml'))
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/tools/mimetypes.py", line 205, in guess_mimetype
    mimetype = _guesser(bin_data[:MIMETYPE_HEAD_SIZE])
                        ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
TypeError: 'bool' object is not subscriptable

The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
    RPC_ERROR
        at makeErrorFromResponse (https://c4a8.odoo.com/web/assets/4f873cc/web.assets_web.min.js:3178:165)
        at XMLHttpRequest.<anonymous> (https://c4a8.odoo.com/web/assets/4f873cc/web.assets_web.min.js:3184:13)
```