### PR TITLE
[16.0][FIX] fs_attachment: bound GC cursor with per-transaction timeouts

### DIFF
--- a/fs_attachment/__manifest__.py
+++ b/fs_attachment/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Base Attachment Object Store",
     "summary": "Store attachments on external object store",
-    "version": "16.0.2.0.1",
+    "version": "16.0.2.0.2",
     "author": "Camptocamp, ACSONE SA/NV, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "development_status": "Beta",

--- a/fs_attachment/models/fs_file_gc.py
+++ b/fs_attachment/models/fs_file_gc.py
@@ -44,6 +44,18 @@ class FsFileGC(models.Model):
 
         with closing(self.env.registry.cursor()) as cr:
             try:
+                # Bound this cursor so it cannot hold a row lock on
+                # fs_file_gc indefinitely. Without these guards, a slow
+                # external storage backend (e.g. S3, Azure Blob) can leave
+                # the cursor "idle in transaction" while waiting on I/O,
+                # serialising every attachment write behind the unique
+                # constraint lock on fs_file_gc.store_fname. Every queued
+                # POST /mail/attachment/upload then times out at the
+                # session statement_timeout and returns a 500 HTML page,
+                # which the frontend tries to JSON.parse and fails with
+                # "Unexpected token '<', \"<!DOCTYPE\"...".
+                cr.execute("SET LOCAL statement_timeout = '30s'")
+                cr.execute("SET LOCAL idle_in_transaction_session_timeout = '60s'")
                 yield cr
             except Exception:
                 cr.rollback()

--- a/fs_attachment/readme/newsfragments/gc_cursor_timeout.bugfix
+++ b/fs_attachment/readme/newsfragments/gc_cursor_timeout.bugfix
@@ -1,0 +1,15 @@
+Bound the GC cursor with per-transaction timeouts.
+
+The secondary cursor opened by ``FsFileGC._in_new_cursor`` had no upper
+bound, so a slow or unresponsive external storage backend (observed on
+Azure Blob, same class of issue applies to S3) could leave it
+``idle in transaction`` while waiting on network I/O. The cursor kept a
+row lock on ``fs_file_gc`` (via the ``store_fname`` unique constraint in
+``_mark_for_gc``), serialising every concurrent attachment write until
+the Odoo session ``statement_timeout`` killed it — by which time every
+``POST /mail/attachment/upload`` was returning a 500 HTML page, which
+the frontend tried to ``JSON.parse`` and failed with
+``Unexpected token '<', "<!DOCTYPE"...``. A ``SET LOCAL statement_timeout``
+and ``SET LOCAL idle_in_transaction_session_timeout`` on the new cursor
+cap the damage to 30-60 s and let the main transaction fail fast instead
+of stalling the whole instance.


### PR DESCRIPTION
## Problem

`FsFileGC._in_new_cursor` opens a secondary cursor to record files for garbage collection, but that cursor has no `statement_timeout` nor `idle_in_transaction_session_timeout`. If the external storage backend (fsspec — verified with Azure Blob, same failure mode applies to S3 or any high-latency backend) stalls the transaction that opened it, the cursor sits `idle in transaction` while keeping the row lock taken by:

```python
INSERT INTO fs_file_gc (store_fname, ...) VALUES (...) ON CONFLICT DO NOTHING
```

Because `fs_file_gc.store_fname` has a unique constraint, every concurrent attachment write that tries to mark the same (or sometimes any) row serialises behind that lock until the main session's `statement_timeout` fires — on Odoo.sh the default is 900 s.

When that finally happens, the blocked `POST /mail/attachment/upload` (and `/web/binary/upload_attachment`) returns a 500 with the standard Odoo error HTML. The web client's `FileInput.uploadFiles` pipes that response straight into `JSON.parse`, which surfaces as:

```
UncaughtPromiseError > SyntaxError
Unexpected token '<', "<!DOCTYPE "... is not valid JSON
    at JSON.parse (<anonymous>)
    at FileInput.uploadFiles
```

We observed this in production 2026-04-21: 6 `idle in transaction` cursors (holding the `fs_storage`/`ir_cron`/`res_users` reads that the ORM triggers when opening `env()` on a fresh cursor) locked the table for ~40 min until ops killed them with `pg_terminate_backend`. During that window every helpdesk compose upload hung.

## Fix

Add two `SET LOCAL` statements at the top of the cursor context manager:

```python
cr.execute("SET LOCAL statement_timeout = '30s'")
cr.execute("SET LOCAL idle_in_transaction_session_timeout = '60s'")
```

`SET LOCAL` scopes both values to the current transaction, so they don't leak into the pooled connection on commit. The numbers are generous (an Azure Blob write should complete in under a second) but tight enough that PostgreSQL kills the offending cursor long before the main session's `statement_timeout` can cascade into user-visible failures.

## Test plan

- [x] Validated in production (Odoo.sh, DB with `autovacuum_gc` enabled on Azure Blob storage). After deployment: 0 `idle in transaction` zombies holding `fs_file_gc` locks under sustained upload load.
- [ ] Happy-path GC still works: `SELECT count(*) FROM fs_file_gc` decreases on `@api.autovacuum` runs.
- [ ] Simulated backend stall: block egress to storage briefly, verify `_mark_for_gc` raises inside 30 s instead of hanging 900 s.

## Other versions

Happy to forward-port once `16.0` is reviewed — the code is identical on `17.0`/`18.0`/`19.0` as of today's tip. Let me know the preferred workflow.