### PR TITLE
[18.0][FIX] storage_media: missing deletion of files

### DIFF
--- a/storage_media/models/storage_media.py
+++ b/storage_media/models/storage_media.py
@@ -38,3 +38,7 @@ class StorageMedia(models.Model):
         return self.env["storage.backend"]._get_backend_id_from_param(
             self.env, "storage.media.backend_id"
         )
+
+    def unlink(self):
+        files = self.mapped("file_id")
+        return super().unlink() and files.unlink()

--- a/storage_media/tests/test_storage_media.py
+++ b/storage_media/tests/test_storage_media.py
@@ -27,3 +27,10 @@ class StorageMediaCase(TransactionComponentCase):
         media = self.env["storage.media"].create({"name": self.filename})
         self.assertEqual(media.file_type, "media")
         self.assertIsNotNone(media.backend_id)
+
+    def test_unlink(self):
+        media = self.env["storage.media"].create({"name": self.filename})
+        stfile = media.file_id
+        media.unlink()
+        self.assertEqual(stfile.to_delete, True)
+        self.assertEqual(stfile.active, False)


### PR DESCRIPTION
The `unlink` hook was missing from the storage media, causing the files not being marked to be deleted when a storage media record was deleted