### PR TITLE
[19.0][IMP] fs_storage: Increase preview iframe z-index

### DIFF
--- a/fs_folder/static/src/preview_iframe/preview_iframe.scss
+++ b/fs_folder/static/src/preview_iframe/preview_iframe.scss
@@ -8,7 +8,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    z-index: 1000;
+    z-index: 9999;
 
     .iframe-container {
         position: relative;


### PR DESCRIPTION
### Issue
Currently, the status bar in the form view has a `z-index` of `1020`, which is higher than the preview iframe’s `z-index` of `1000`.

As a result, the status bar is displayed above the preview iframe.

<img width="1143" height="447" alt="image" src="https://github.com/user-attachments/assets/5e156116-aff1-4bcc-9de7-db995e5eddb4" />

### Solution
Increase the preview iframe’s `z-index` to `9999` to ensure it is displayed correctly above the form view status bar.