### PR TITLE
[18.0][IMP] fs_storage: add _move_file helper

### DIFF
--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -10,6 +10,7 @@ import logging
 import os.path
 import re
 import warnings
+from pathlib import PurePath
 from typing import AnyStr
 
 import fsspec
@@ -819,3 +820,12 @@ class FSStorage(models.Model):
         while hasattr(fs, "fs"):
             fs = fs.fs
         return fs
+
+    def _move_file(self, from_dir_str, to_dir_str, filename):
+        self.ensure_one()
+        src = (PurePath(from_dir_str) / filename).as_posix()
+        if not self.fs.exists(src):
+            return False
+        dst = (PurePath(to_dir_str) / filename).as_posix()
+        self.env.cr.postcommit.add(functools.partial(self.fs.move, src, dst))
+        return True

--- a/fs_storage/tests/test_fs_storage.py
+++ b/fs_storage/tests/test_fs_storage.py
@@ -304,3 +304,22 @@ class TestFSStorage(TestFSStorageCase):
             safe_eval.safe_eval(
                 "env['fs.storage'].search([]).unlink()", {"env": self.env}
             )
+
+    def test_move_file(self):
+        src_dir = "src"
+        dst_dir = "dst"
+        self.backend.fs.makedirs(src_dir, exist_ok=True)
+        self.backend.fs.makedirs(dst_dir, exist_ok=True)
+        self._create_file(self.backend, f"{src_dir}/{self.filename}", self.filedata)
+
+        res = self.backend._move_file(src_dir, dst_dir, self.filename)
+        self.assertTrue(res)
+        # The actual move runs on post-commit, so until then the file
+        # must still live in the source directory.
+        self.assertTrue(self.backend.fs.exists(f"{src_dir}/{self.filename}"))
+        self.assertFalse(self.backend.fs.exists(f"{dst_dir}/{self.filename}"))
+
+        self.env.cr.postcommit.run()
+
+        self.assertFalse(self.backend.fs.exists(f"{src_dir}/{self.filename}"))
+        self.assertTrue(self.backend.fs.exists(f"{dst_dir}/{self.filename}"))


### PR DESCRIPTION
Add a generic `_move_file` helper on `fs.storage`: checks that the source file exists and schedules `fs.move` as a post-commit hook so the storage stays in sync with the DB transaction.