### PR TITLE
[16.0][FW] [18.0][IMP] fs_attachment: improve attachment storage handling of files without body (size=0)

### DIFF
--- a/.oca/oca-port/blacklist/fs_attachment.json
+++ b/.oca/oca-port/blacklist/fs_attachment.json
@@ -2,6 +2,9 @@
   "pull_requests": {
     "OCA/storage#344": "migration PR",
     "OCA/storage#368": "CI fix",
-    "OCA/storage#402": "FP from 16 to 17"
+    "OCA/storage#402": "FP from 16 to 17",
+    "orphaned_commits": "Migration commits for 18.0",
+    "OCA/storage#460": "Already into 16.0",
+    "OCA/storage#514": "Already into 16.0"
   }
 }

--- a/fs_attachment/models/ir_attachment.py
+++ b/fs_attachment/models/ir_attachment.py
@@ -260,6 +260,18 @@ class IrAttachment(models.Model):
             storage = super()._storage()
         return storage
 
+    @api.depends("store_fname", "db_datas")
+    def _compute_raw(self):
+        """Always expose raw payload as bytes.
+
+        Some callers (e.g. account EDI helpers) slice the value returned by
+        ``raw`` and crash when it is ``False`` for 0-byte attachments.
+        """
+        res = super()._compute_raw()
+        false_attachments = self.filtered(lambda att: not att.raw)
+        false_attachments.raw = b""
+        return res
+
     @api.model_create_multi
     def create(self, vals_list):
         """
@@ -701,9 +713,10 @@ class IrAttachment(models.Model):
         self.ensure_one()
         _logger.info("inspecting attachment %s (%d)", self.name, self.id)
         fname = self.store_fname
-        storage = fname.partition("://")[0]
-        if self._is_storage_disabled(storage):
-            fname = False
+        if fname:
+            storage = fname.partition("://")[0]
+            if self._is_storage_disabled(storage):
+                fname = False
         if fname:
             # migrating from filesystem filestore
             # or from the old 'store_fname' without the bucket name

--- a/fs_attachment/tests/test_fs_attachment.py
+++ b/fs_attachment/tests/test_fs_attachment.py
@@ -75,6 +75,12 @@ class TestFSAttachment(TestFSAttachmentCommon):
         with attachment.open("rb") as f:
             self.assertEqual(f.read(), new_content)
 
+    def test_create_attachment_with_no_payload_has_bytes_raw(self):
+        attachment = self.ir_attachment_model.create({"name": "empty.txt"})
+
+        self.assertEqual(attachment.raw, b"")
+        self.assertEqual(attachment.file_size, 0)
+
     def test_open_attachment_in_db(self):
         self.env["ir.config_parameter"].sudo().set_param("ir_attachment.location", "db")
         content = b"This is a test attachment in db"


### PR DESCRIPTION
Port from 18.0 to 16.0:
- #594

The following PRs have been blacklisted:
- #: Migration commits for 18.0
- #460: Already into 16.0
- #514: Already into 16.0
