### PR TITLE
[16.0][IMP] fs_storage: replace {db_name} in directory_path, fs_attachment …

### DIFF
--- a/fs_attachment/models/fs_storage.py
+++ b/fs_attachment/models/fs_storage.py
@@ -3,9 +3,10 @@
 
 from __future__ import annotations
 
+from psycopg2.extensions import AsIs
+
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import ValidationError
-from odoo.tools import SQL
 from odoo.tools.safe_eval import const_eval
 
 from .ir_attachment import IrAttachment
@@ -497,7 +498,7 @@ class FsStorage(models.Model):
         # This is needed when {db_name} is used in directory path.
         # Due to the use of server_environment, there is no directory_path column to
         # filter so recompute all.
-        self.env.cr.execute(SQL("SELECT id FROM %s", SQL.identifier(self._table)))
+        self.env.cr.execute("SELECT id FROM %s", (AsIs(self._table),))
         records = self.browse(row[0] for row in self.env.cr.fetchall())
         if records:
             self.env.add_to_compute(self._fields["base_url_for_files"], records)

--- a/fs_attachment/models/fs_storage.py
+++ b/fs_attachment/models/fs_storage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import ValidationError
+from odoo.tools import SQL
 from odoo.tools.safe_eval import const_eval
 
 from .ir_attachment import IrAttachment
@@ -405,15 +406,15 @@ class FsStorage(models.Model):
     def _must_use_filename_obfuscation(self, code):
         return self.sudo().get_by_code(code).use_filename_obfuscation
 
-    @api.depends("base_url", "is_directory_path_in_url")
+    @api.depends("base_url", "is_directory_path_in_url", "directory_path")
     def _compute_base_url_for_files(self):
         for rec in self:
             if not rec.base_url:
                 rec.base_url_for_files = ""
                 continue
             parts = [rec.base_url]
-            if rec.is_directory_path_in_url and rec.directory_path:
-                parts.append(rec.directory_path)
+            if rec.is_directory_path_in_url and rec.get_directory_path():
+                parts.append(rec.get_directory_path())
             rec.base_url_for_files = self._normalize_url("/".join(parts))
 
     @api.model
@@ -489,3 +490,16 @@ class FsStorage(models.Model):
         attachments = self.env["ir.attachment"].search(domain)
         attachments._compute_fs_url()
         attachments._compute_fs_url_path()
+
+    @api.model
+    def _setup_complete(self):
+        # Force recompute of base_url_for_files.
+        # This is needed when {db_name} is used in directory path.
+        # Due to the use of server_environment, there is no directory_path column to
+        # filter so recompute all.
+        self.env.cr.execute(SQL("SELECT id FROM %s", SQL.identifier(self._table)))
+        records = self.browse(row[0] for row in self.env.cr.fetchall())
+        if records:
+            self.env.add_to_compute(self._fields["base_url_for_files"], records)
+        # recompute is done at the end of the caller (registry::setup_models)
+        return super()._setup_complete()

--- a/fs_attachment/readme/newsfragments/db_name.feature
+++ b/fs_attachment/readme/newsfragments/db_name.feature
@@ -1,0 +1,1 @@
+Adapt to handle {db_name} in directory_path.

--- a/fs_attachment/tests/test_fs_storage.py
+++ b/fs_attachment/tests/test_fs_storage.py
@@ -412,3 +412,8 @@ class TestFsStorage(TestFSAttachmentCommon):
         self.assertTrue(parts)
         self.assertTrue(checksum)
         self.assertEqual(fs_url_1, fs_url_2)
+
+    def test_directory_path_substitution(self):
+        self.temp_backend.directory_path += "/{db_name}"
+        self.assertEqual("", self.temp_backend.base_url_for_files)
+        self.assertNotIn("{db_name}", self.temp_backend.base_url_for_files)

--- a/fs_attachment_s3/models/ir_attachment.py
+++ b/fs_attachment_s3/models/ir_attachment.py
@@ -1,4 +1,5 @@
 # Copyright 2025 ACSONE SA/NV
+# Copyright 2025 XCG SAS
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from urllib.parse import urlparse
 
@@ -59,7 +60,7 @@ class IrAttachment(models.Model):
         storage = self.env["fs.storage"].sudo().get_by_code(storage_code)
         root_fs = storage._get_root_filesystem(fs)
         s3_client = root_fs.s3
-        bucket_name = storage.directory_path.strip("/").rstrip("/")
+        bucket_name = storage.get_directory_path().strip("/").rstrip("/")
         if storage.s3_uses_signed_url_for_x_sendfile:
             file_url = storage._s3_call_generate_presigned_url(
                 s3_client,

--- a/fs_attachment_s3/readme/newsfragments/db_name.feature
+++ b/fs_attachment_s3/readme/newsfragments/db_name.feature
@@ -1,0 +1,1 @@
+Adapt to handle {db_name} in directory_path.

--- a/fs_storage/README.rst
+++ b/fs_storage/README.rst
@@ -176,6 +176,10 @@ In your configuration section, you can specify the value for the following field
 * `options`
 * `directory_path`
 
+When evaluating directory_path, `{db_name}` is replaced by the database name.
+This is usefull in multi-tenant with a setup completly controlled by
+configuration files.
+
 Migration from storage_backend
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/fs_storage/models/fs_storage.py
+++ b/fs_storage/models/fs_storage.py
@@ -151,8 +151,10 @@ class FSStorage(models.Model):
             """,
     )
 
+    # When accessing this field, use the method get_directory_path instead so that
+    # parameter expansion is done.
     directory_path = fields.Char(
-        help="Relative path to the directory to store the file"
+        help="Relative path to the directory to store the file",
     )
 
     # the next fields are used to display documentation to help the user
@@ -217,6 +219,7 @@ class FSStorage(models.Model):
             "options": {},
             "directory_path": {},
             "eval_options_from_env": {},
+            "check_connection_method": {},
         }
 
     @api.model_create_multi
@@ -242,6 +245,14 @@ class FSStorage(models.Model):
     @prevent_call_from_safe_eval("unlink")
     def _check_no_safe_eval_call(self):
         pass
+
+    def get_directory_path(self):
+        """Returns directory path with substitution done."""
+        return (
+            self.directory_path.format(db_name=self.env.cr.dbname)
+            if isinstance(self.directory_path, str)
+            else self.directory_path
+        )
 
     @api.model
     @tools.ormcache()
@@ -489,7 +500,7 @@ class FSStorage(models.Model):
             options["auth"] = tuple(options["auth"])
         options = self._recursive_add_odoo_storage_path(options)
         fs = fsspec.filesystem(self.protocol, **options)
-        directory_path = self.directory_path
+        directory_path = self.get_directory_path()
         if directory_path:
             fs = fsspec.filesystem("rooted_dir", path=directory_path, fs=fs)
         return fs

--- a/fs_storage/readme/USAGE.rst
+++ b/fs_storage/readme/USAGE.rst
@@ -70,6 +70,10 @@ In your configuration section, you can specify the value for the following field
 * `options`
 * `directory_path`
 
+When evaluating directory_path, `{db_name}` is replaced by the database name.
+This is usefull in multi-tenant with a setup completly controlled by
+configuration files.
+
 Migration from storage_backend
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/fs_storage/readme/newsfragments/db_name.feature
+++ b/fs_storage/readme/newsfragments/db_name.feature
@@ -1,0 +1,1 @@
+Replace {db_name} by the database name in directory_path

--- a/fs_storage/static/description/index.html
+++ b/fs_storage/static/description/index.html
@@ -527,6 +527,9 @@ In your configuration section, you can specify the value for the following field
 <li><cite>options</cite></li>
 <li><cite>directory_path</cite></li>
 </ul>
+<p>When evaluating directory_path, <cite>{db_name}</cite> is replaced by the database name.
+This is usefull in multi-tenant with a setup completly controlled by
+configuration files.</p>
 </div>
 <div class="section" id="migration-from-storage-backend">
 <h3><a class="toc-backref" href="#toc-entry-4">Migration from storage_backend</a></h3>

--- a/fs_storage/tests/test_fs_storage.py
+++ b/fs_storage/tests/test_fs_storage.py
@@ -200,3 +200,9 @@ class TestFSStorage(TestFSStorageCase):
             safe_eval.safe_eval(
                 "env['fs.storage'].search([]).unlink()", {"env": self.env}
             )
+
+    def test_directory_path_substitution(self):
+        template = "dir/{db_name}"
+        self.backend.directory_path = template
+        # Assert different (db name should be replaced)
+        self.assertNotEqual(template, self.backend.get_directory_path())


### PR DESCRIPTION
…and fs_attachment_s3: adapt to change

In multi database mode, there was no way to avoid filename collisions when a configuration file is used to define the fs_storage.storage to store attachments.

backport of #379 