### PR TITLE
[18.0][FIX] Allow to use a prefix path and bucket in the directory_path

### DIFF
--- a/fs_attachment_s3/models/ir_attachment.py
+++ b/fs_attachment_s3/models/ir_attachment.py
@@ -62,12 +62,8 @@ class IrAttachment(models.Model):
         # The directory path might contain the bucket and a prefix
         # the part before the first "/" is the bucket
         # the rest is the prefix
-        path_parts = storage.get_directory_path().strip("/").rstrip("/").split("/")
-        bucket_name = path_parts[:1][0]
-        prefix = "/".join(path_parts[1:])
-        s3_key = (
-            f"{prefix}/{file_path.lstrip('/')}" if prefix else file_path.lstrip("/")
-        )
+        bucket_name, *prefix_parts = storage.get_directory_path().strip("/").split("/")
+        s3_key = "/".join(prefix_parts + [file_path.lstrip("/")])
         if storage.s3_uses_signed_url_for_x_sendfile:
             file_url = storage._s3_call_generate_presigned_url(
                 s3_client,

--- a/fs_attachment_s3/models/ir_attachment.py
+++ b/fs_attachment_s3/models/ir_attachment.py
@@ -59,18 +59,26 @@ class IrAttachment(models.Model):
         storage = self.env["fs.storage"].sudo().get_by_code(storage_code)
         root_fs = storage._get_root_filesystem(fs)
         s3_client = root_fs.s3
-        bucket_name = storage.get_directory_path().strip("/").rstrip("/")
+        # The directory path might contain the bucket and a prefix
+        # the part before the first "/" is the bucket
+        # the rest is the prefix
+        path_parts = storage.get_directory_path().strip("/").rstrip("/").split("/")
+        bucket_name = path_parts[:1][0]
+        prefix = "/".join(path_parts[1:])
+        s3_key = (
+            f"{prefix}/{file_path.lstrip('/')}" if prefix else file_path.lstrip("/")
+        )
         if storage.s3_uses_signed_url_for_x_sendfile:
             file_url = storage._s3_call_generate_presigned_url(
                 s3_client,
                 "get_object",
-                Params={"Bucket": bucket_name, "Key": file_path},
+                Params={"Bucket": bucket_name, "Key": s3_key},
                 ExpiresIn=storage.s3_signed_url_expiration,
             )
         else:
             file_url = (
                 f"{s3_client.meta.endpoint_url.rstrip('/')}/"
-                f"{bucket_name}/{file_path.lstrip('/')}"
+                f"{bucket_name}/{s3_key.lstrip('/')}"
             )
 
         parsed_url = urlparse(file_url)

--- a/fs_attachment_s3/readme/newsfragments/b17de9.bugfix.md
+++ b/fs_attachment_s3/readme/newsfragments/b17de9.bugfix.md
@@ -1,0 +1,3 @@
+Allow to use a prefix path and bucket in the directory_path on fs.storage
+When the directory_path parameter is configured as <bucketname>/<someprefix>
+the presigned url generation failed with a botocore error: "Invalid bucket name".

--- a/fs_attachment_s3/tests/test_fs_attachment_s3.py
+++ b/fs_attachment_s3/tests/test_fs_attachment_s3.py
@@ -33,3 +33,37 @@ class TestFSAttachementS3(TestFSAttachmentS3Common):
             "/fs_x_sendfile/http/minio.minio/test-bucket/dir/sub/fake_s3_file.txt",
             f"The X-Accel-Redirect path should match the expected format. ({url})",
         )
+
+    def test_get_x_sendfile_path_s3_signed_with_prefix(self):
+        """Test the path generation when the directory path has a prefix."""
+        self.s3_backend.write(
+            {
+                "s3_uses_signed_url_for_x_sendfile": True,
+                "s3_signed_url_expiration": 60,
+                "directory_path": "test-bucket/test-prefix",
+            }
+        )
+
+        url = self.fake_attachment_s3._get_x_sendfile_path()
+        self.assertTrue(
+            url.startswith(
+                "/fs_x_sendfile/http/minio.minio/"
+                "test-bucket/test-prefix/dir/sub/fake_s3_file.txt?"
+            ),
+            f"The URL should include the prefix. ({url})",
+        )
+
+    def test_get_x_sendfile_path_with_prefix(self):
+        """Test the unsigned path generation with a prefix."""
+        self.s3_backend.write(
+            {
+                "s3_uses_signed_url_for_x_sendfile": False,
+                "directory_path": "test-bucket/test-prefix",
+            }
+        )
+        url = self.fake_attachment_s3._get_x_sendfile_path()
+        self.assertEqual(
+            url,
+            "/fs_x_sendfile/http/minio.minio/test-bucket/test-prefix/dir/sub/fake_s3_file.txt",
+            f"The URL should include the prefix. ({url})",
+        )


### PR DESCRIPTION
supersedes #616 to properly specify the change history and improves code readability while preserving the initial authorship