### PR TITLE
Security: Path Traversal in RootedDirFileSystem._join

### DIFF
--- a/fs_storage/rooted_dir_file_system.py
+++ b/fs_storage/rooted_dir_file_system.py
@@ -27,7 +27,9 @@ class RootedDirFileSystem(DirFileSystem):
         # we need to normalize the path separator.
         path_posix = os.path.normpath(make_path_posix(path))
         root_posix = os.path.normpath(make_path_posix(self.path))
-        if not path_posix.startswith(root_posix):
+        if not root_posix.endswith("/"):
+            root_posix = root_posix + "/"
+        if path_posix != root_posix.rstrip("/") and not path_posix.startswith(root_posix):
             raise PermissionError(
                 f"Path {path} is not a subpath of the root path {self.path}"
             )


### PR DESCRIPTION
## Summary

Security: Path Traversal in RootedDirFileSystem._join

## Problem

**Severity**: `High` | **File**: `fs_storage/rooted_dir_file_system.py:L28`

The `RootedDirFileSystem._join` method attempts to prevent path traversal by checking if the resolved path starts with the root path. However, the check uses `os.path.normpath` and `make_path_posix` which may not handle all path traversal techniques. Specifically, the `startswith` check is vulnerable if the root path is not properly normalized or if an attacker can craft a path that passes the check but still escapes the root. More critically, the `startswith` check with `root_posix` can be bypassed if the root path doesn't end with a separator and the path contains the root as a prefix. For example, if root is `/data/storage`, a path like `/data/storage_extra` would pass the startswith check but is outside the intended directory. Additionally, the method doesn't handle symlink attacks or race conditions.

## Solution

Ensure the root path ends with a path separator before using startswith, or use a more robust path containment check. Consider using `os.path.commonpath` or ensuring both paths are resolved with `os.path.realpath` before comparison. Also handle the case where paths are exactly equal.

## Changes

- `fs_storage/rooted_dir_file_system.py` (modified)