### PR TITLE
[18.0][IMP] storage_file: improve public/private behavior

### DIFF
--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,3 +1,4 @@
 [checklog-odoo]
 ignore=
     WARNING.* 0 failed, 0 error\(s\).*
+    WARNING.*DeprecationWarning: PyUnicode_FromUnicode\(NULL, size\) is deprecated; use PyUnicode_New\(\) instead

--- a/storage_file/__manifest__.py
+++ b/storage_file/__manifest__.py
@@ -23,5 +23,6 @@
         "data/ir_cron.xml",
         "data/storage_backend.xml",
         "wizards/swap_backend.xml",
+        "data/ir_config_parameter.xml",
     ],
 }

--- a/storage_file/__manifest__.py
+++ b/storage_file/__manifest__.py
@@ -22,5 +22,6 @@
         "security/storage_file.xml",
         "data/ir_cron.xml",
         "data/storage_backend.xml",
+        "data/ir_config_parameter.xml",
     ],
 }

--- a/storage_file/controllers/main.py
+++ b/storage_file/controllers/main.py
@@ -1,7 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from werkzeug.exceptions import NotFound
 
 from odoo import http
+from odoo.exceptions import AccessError
 from odoo.http import request
 
 
@@ -13,6 +15,15 @@ class StorageFileController(http.Controller):
         storage_file = request.env["storage.file"].get_from_slug_name_with_id(
             slug_name_with_id
         )
+        if not storage_file.exists():
+            raise NotFound()
+        try:
+            storage_file.check_access("read")
+        except AccessError as err:
+            # If you don't have access you should not know
+            # that the file exists (as anon user).
+            # You can inspect the traceback to see it's coming from an access error.
+            raise NotFound() from err
         stream = request.env["ir.binary"]._get_stream_from(
             storage_file, field_name="data"
         )

--- a/storage_file/controllers/main.py
+++ b/storage_file/controllers/main.py
@@ -1,7 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from werkzeug.exceptions import NotFound
 
 from odoo import http
+from odoo.exceptions import AccessError
 from odoo.http import request
 
 
@@ -13,6 +15,12 @@ class StorageFileController(http.Controller):
         storage_file = request.env["storage.file"].get_from_slug_name_with_id(
             slug_name_with_id
         )
+        if not storage_file.exists():
+            raise NotFound()
+        try:
+            storage_file.check_access("read")
+        except AccessError as err:
+            raise NotFound() from err
         stream = request.env["ir.binary"]._get_stream_from(
             storage_file, field_name="data"
         )

--- a/storage_file/data/ir_config_parameter.xml
+++ b/storage_file/data/ir_config_parameter.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="storage_file_backend" model="ir.config_parameter">
+        <field name="key">storage.file.backend_id</field>
+        <field name="value" ref="storage_backend.default_storage_backend" />
+    </record>
+</odoo>

--- a/storage_file/models/storage_backend.py
+++ b/storage_file/models/storage_backend.py
@@ -145,7 +145,10 @@ class StorageBackend(models.Model):
     def _get_url_for_file(self, storage_file, exclude_base_url=False):
         """Return final full URL for given file."""
         backend = self.sudo()
-        if backend.served_by == "odoo":
+        # Make sure that no matter if you have a CDN URL or not,
+        # you can always access the file via Odoo.
+        force_serve_via_odoo = backend.served_by == "external" and not backend.base_url
+        if backend.served_by == "odoo" or force_serve_via_odoo:
             parts = [
                 self._get_base_url_from_param() if not exclude_base_url else "/",
                 "storage.file",

--- a/storage_file/models/storage_backend.py
+++ b/storage_file/models/storage_backend.py
@@ -145,7 +145,9 @@ class StorageBackend(models.Model):
     def _get_url_for_file(self, storage_file, exclude_base_url=False):
         """Return final full URL for given file."""
         backend = self.sudo()
-        if backend.served_by == "odoo":
+        if backend.served_by == "odoo" or (
+            backend.served_by == "external" and not backend.base_url
+        ):
             parts = [
                 self._get_base_url_from_param() if not exclude_base_url else "/",
                 "storage.file",

--- a/storage_file/models/storage_file.py
+++ b/storage_file/models/storage_file.py
@@ -193,6 +193,8 @@ class StorageFile(models.Model):
 
         :param exclude_base_url: skip base_url
         """
+        if not self.backend_id or not self.relative_path:
+            return ""
         return self.backend_id._get_url_for_file(
             self, exclude_base_url=exclude_base_url
         )

--- a/storage_file/models/storage_file.py
+++ b/storage_file/models/storage_file.py
@@ -65,6 +65,27 @@ class StorageFile(models.Model):
         "res.company", "Company", default=lambda self: self.env.user.company_id.id
     )
     file_type = fields.Selection([])
+    is_public = fields.Boolean(
+        compute="_compute_is_public",
+        compute_sudo=True,
+        search="_search_is_public",
+        # Not stored to avoid massive recomputes when the backend flag changes.
+        help="Reflects the `is_public` flag of the related backend.",
+    )
+
+    @api.depends("backend_id.is_public")
+    def _compute_is_public(self):
+        for rec in self:
+            rec.is_public = rec.backend_id.is_public
+
+    def _search_is_public(self, operator, value):
+        # Look up matching backends with sudo so that users with limited ACL
+        # on `storage.backend` can still filter their accessible files by
+        # public flag.
+        backends = (
+            self.env["storage.backend"].sudo().search([("is_public", operator, value)])
+        )
+        return [("backend_id", "in", backends.ids)]
 
     _sql_constraints = [
         (

--- a/storage_file/models/storage_file.py
+++ b/storage_file/models/storage_file.py
@@ -30,7 +30,11 @@ class StorageFile(models.Model):
 
     name = fields.Char(required=True, index=True)
     backend_id = fields.Many2one(
-        "storage.backend", "Storage", index=True, required=True
+        "storage.backend",
+        "Storage",
+        index=True,
+        required=True,
+        default=lambda self: self._get_default_backend_id(),
     )
     url = fields.Char(compute="_compute_url", help="HTTP accessible path to the file")
     url_path = fields.Char(
@@ -77,6 +81,12 @@ class StorageFile(models.Model):
     def _compute_is_public(self):
         for rec in self:
             rec.is_public = rec.backend_id.is_public
+
+    @api.model
+    def _get_default_backend_id(self):
+        return self.env["storage.backend"]._get_backend_id_from_param(
+            self.env, "storage.file.backend_id"
+        )
 
     def _search_is_public(self, operator, value):
         # Look up matching backends with sudo so that users with limited ACL

--- a/storage_file/models/storage_file.py
+++ b/storage_file/models/storage_file.py
@@ -206,6 +206,8 @@ class StorageFile(models.Model):
 
         :param exclude_base_url: skip base_url
         """
+        if not self.backend_id or not self.relative_path:
+            return ""
         return self.backend_id._get_url_for_file(
             self, exclude_base_url=exclude_base_url
         )

--- a/storage_file/security/ir.model.access.csv
+++ b/storage_file/security/ir.model.access.csv
@@ -1,5 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_storage_file_edit,storage_file edit,model_storage_file,base.group_system,1,1,1,1
 access_storage_file_read_public,storage_file public read,model_storage_file,base.group_user,1,0,0,0
+access_storage_file_read_portal,storage_file portal read,model_storage_file,base.group_public,1,0,0,0
 access_storage_file_replace,storage_file_replace public,model_storage_file_replace,base.group_user,1,1,1,1
 access_storage_file_swap_backend,storage_file_swap_backend admin,model_storage_file_swap_backend,base.group_system,1,1,1,1

--- a/storage_file/security/ir.model.access.csv
+++ b/storage_file/security/ir.model.access.csv
@@ -1,4 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_storage_file_edit,storage_file edit,model_storage_file,base.group_system,1,1,1,1
 access_storage_file_read_public,storage_file public read,model_storage_file,base.group_user,1,0,0,0
+access_storage_file_read_portal,storage_file portal read,model_storage_file,base.group_public,1,0,0,0
 access_storage_file_replace,storage_file_replace public,model_storage_file_replace,base.group_user,1,1,1,1

--- a/storage_file/security/storage_file.xml
+++ b/storage_file/security/storage_file.xml
@@ -13,4 +13,15 @@
         <field name="perm_create" eval="False" />
         <field name="perm_unlink" eval="False" />
     </record>
+    <!--Internal users can read all files (public and private)-->
+    <record id="ir_rule_storage_file_internal" model="ir.rule">
+        <field name="name">Storage file internal read all</field>
+        <field name="model_id" ref="model_storage_file" />
+        <field name="groups" eval="[(4, ref('base.group_user'))]" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="perm_read" eval="True" />
+        <field name="perm_write" eval="False" />
+        <field name="perm_create" eval="False" />
+        <field name="perm_unlink" eval="False" />
+    </record>
 </odoo>

--- a/storage_file/tests/__init__.py
+++ b/storage_file/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_storage_file
+from . import test_is_public

--- a/storage_file/tests/__init__.py
+++ b/storage_file/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_storage_file
 from . import test_is_public
+from . import test_controller

--- a/storage_file/tests/__init__.py
+++ b/storage_file/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_storage_file
 from . import test_swap_backend
 from . import test_is_public
+from . import test_controller

--- a/storage_file/tests/__init__.py
+++ b/storage_file/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_storage_file
 from . import test_swap_backend
+from . import test_is_public

--- a/storage_file/tests/test_controller.py
+++ b/storage_file/tests/test_controller.py
@@ -1,0 +1,156 @@
+# Copyright 2026 Camptocamp SA
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import base64
+
+from odoo.tests.common import HttpCase, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestStorageFileController(HttpCase):
+    """Test the /storage.file/ controller with public/private and odoo/external."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.data = b"Hello, storage!"
+        cls.filedata = base64.b64encode(cls.data)
+        cls.backend_odoo_public = cls.env["storage.backend"].create(
+            {
+                "name": "Odoo Public",
+                "backend_type": "filesystem",
+                "served_by": "odoo",
+                "is_public": True,
+                "filename_strategy": "name_with_id",
+            }
+        )
+        cls.backend_odoo_private = cls.env["storage.backend"].create(
+            {
+                "name": "Odoo Private",
+                "backend_type": "filesystem",
+                "served_by": "odoo",
+                "is_public": False,
+                "filename_strategy": "name_with_id",
+            }
+        )
+        cls.backend_ext_public = cls.env["storage.backend"].create(
+            {
+                "name": "Ext Public (no CDN)",
+                "backend_type": "filesystem",
+                "served_by": "external",
+                "base_url": "",
+                "is_public": True,
+                "filename_strategy": "name_with_id",
+            }
+        )
+        cls.backend_ext_private = cls.env["storage.backend"].create(
+            {
+                "name": "Ext Private (no CDN)",
+                "backend_type": "filesystem",
+                "served_by": "external",
+                "base_url": "",
+                "is_public": False,
+                "filename_strategy": "name_with_id",
+            }
+        )
+        cls.file_odoo_public = cls.env["storage.file"].create(
+            {
+                "name": "pub-odoo.txt",
+                "backend_id": cls.backend_odoo_public.id,
+                "data": cls.filedata,
+            }
+        )
+        cls.file_odoo_private = cls.env["storage.file"].create(
+            {
+                "name": "priv-odoo.txt",
+                "backend_id": cls.backend_odoo_private.id,
+                "data": cls.filedata,
+            }
+        )
+        cls.file_ext_public = cls.env["storage.file"].create(
+            {
+                "name": "pub-ext.txt",
+                "backend_id": cls.backend_ext_public.id,
+                "data": cls.filedata,
+            }
+        )
+        cls.file_ext_private = cls.env["storage.file"].create(
+            {
+                "name": "priv-ext.txt",
+                "backend_id": cls.backend_ext_private.id,
+                "data": cls.filedata,
+            }
+        )
+        cls.internal_user = (
+            cls.env["res.users"]
+            .with_context(no_reset_password=True)
+            .create(
+                {
+                    "name": "Storage Test User",
+                    "login": "storage_test_user",
+                    "password": "storage_test_user",
+                    "groups_id": [
+                        (4, cls.env.ref("base.group_user").id),
+                    ],
+                }
+            )
+        )
+
+    def _url_for(self, storage_file):
+        return f"/storage.file/{storage_file.slug}"
+
+    # ---- Public user (anonymous) ----
+
+    def test_public_user_odoo_public(self):
+        """Public user + public odoo backend -> 200."""
+        resp = self.url_open(self._url_for(self.file_odoo_public))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content, self.data)
+
+    def test_public_user_odoo_private(self):
+        """Public user + private odoo backend -> 404."""
+        resp = self.url_open(self._url_for(self.file_odoo_private))
+        self.assertEqual(resp.status_code, 404)
+
+    def test_public_user_ext_public(self):
+        """Public user + public external backend (no CDN) -> 200."""
+        resp = self.url_open(self._url_for(self.file_ext_public))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content, self.data)
+
+    def test_public_user_ext_private(self):
+        """Public user + private external backend (no CDN) -> 404."""
+        resp = self.url_open(self._url_for(self.file_ext_private))
+        self.assertEqual(resp.status_code, 404)
+
+    # ---- Internal (authenticated) user ----
+
+    def test_internal_user_odoo_public(self):
+        """Internal user + public odoo backend -> 200."""
+        self.authenticate("storage_test_user", "storage_test_user")
+        resp = self.url_open(self._url_for(self.file_odoo_public))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content, self.data)
+
+    def test_internal_user_odoo_private(self):
+        """Internal user + private odoo backend -> 200."""
+        self.authenticate("storage_test_user", "storage_test_user")
+        resp = self.url_open(self._url_for(self.file_odoo_private))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content, self.data)
+
+    def test_internal_user_ext_public(self):
+        """Internal user + public external backend (no CDN) -> 200."""
+        self.authenticate("storage_test_user", "storage_test_user")
+        resp = self.url_open(self._url_for(self.file_ext_public))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content, self.data)
+
+    def test_internal_user_ext_private(self):
+        """Internal user + private external backend (no CDN) -> 200."""
+        self.authenticate("storage_test_user", "storage_test_user")
+        resp = self.url_open(self._url_for(self.file_ext_private))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content, self.data)

--- a/storage_file/tests/test_is_public.py
+++ b/storage_file/tests/test_is_public.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Camptocamp SA
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.addons.component.tests.common import TransactionComponentCase
+
+
+class TestStorageFileIsPublic(TransactionComponentCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.backend = cls.env["storage.backend"].create(
+            {"name": "Test backend", "backend_type": "filesystem"}
+        )
+        cls.storage_file = cls.env["storage.file"].create(
+            {
+                "name": "test-public.txt",
+                "backend_id": cls.backend.id,
+                "data": b"aGVsbG8=",  # "hello" base64
+            }
+        )
+
+    def test_reflects_backend_flag(self):
+        self.assertFalse(self.storage_file.is_public)
+        self.backend.is_public = True
+        self.storage_file.invalidate_recordset(["is_public"])
+        self.assertTrue(self.storage_file.is_public)
+
+    def test_search_true(self):
+        self.backend.is_public = True
+        result = self.env["storage.file"].search(
+            [("is_public", "=", True), ("id", "=", self.storage_file.id)]
+        )
+        self.assertIn(self.storage_file, result)
+
+    def test_search_false(self):
+        self.backend.is_public = False
+        result = self.env["storage.file"].search(
+            [("is_public", "=", False), ("id", "=", self.storage_file.id)]
+        )
+        self.assertIn(self.storage_file, result)
+
+    def test_search_with_two_backends(self):
+        public_backend = self.env["storage.backend"].create(
+            {
+                "name": "Public backend",
+                "backend_type": "filesystem",
+                "is_public": True,
+            }
+        )
+        public_file = self.env["storage.file"].create(
+            {
+                "name": "public.txt",
+                "backend_id": public_backend.id,
+                "data": b"aGVsbG8=",
+            }
+        )
+        result = self.env["storage.file"].search([("is_public", "=", True)])
+        self.assertIn(public_file, result)
+        self.assertNotIn(self.storage_file, result)

--- a/storage_file/tests/test_is_public.py
+++ b/storage_file/tests/test_is_public.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Camptocamp SA
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.addons.component.tests.common import TransactionComponentCase
+
+
+class TestStorageFileIsPublic(TransactionComponentCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.backend = cls.env["storage.backend"].create(
+            {"name": "Test backend", "backend_type": "filesystem"}
+        )
+        cls.storage_file = cls.env["storage.file"].create(
+            {
+                "name": "test-public.txt",
+                "backend_id": cls.backend.id,
+                "data": b"aGVsbG8=",  # "hello" base64
+            }
+        )
+
+    def test_reflects_backend_flag(self):
+        self.assertFalse(self.storage_file.is_public)
+        self.backend.is_public = True
+        self.assertTrue(self.storage_file.is_public)
+
+    def test_search_true(self):
+        self.backend.is_public = True
+        result = self.env["storage.file"].search(
+            [("is_public", "=", True), ("id", "=", self.storage_file.id)]
+        )
+        self.assertIn(self.storage_file, result)
+
+    def test_search_false(self):
+        self.backend.is_public = False
+        result = self.env["storage.file"].search(
+            [("is_public", "=", False), ("id", "=", self.storage_file.id)]
+        )
+        self.assertIn(self.storage_file, result)
+
+    def test_search_with_two_backends(self):
+        public_backend = self.env["storage.backend"].create(
+            {
+                "name": "Public backend",
+                "backend_type": "filesystem",
+                "is_public": True,
+            }
+        )
+        public_file = self.env["storage.file"].create(
+            {
+                "name": "public.txt",
+                "backend_id": public_backend.id,
+                "data": b"aGVsbG8=",
+            }
+        )
+        result = self.env["storage.file"].search([("is_public", "=", True)])
+        self.assertIn(public_file, result)
+        self.assertNotIn(self.storage_file, result)

--- a/storage_file/tests/test_storage_file.py
+++ b/storage_file/tests/test_storage_file.py
@@ -110,6 +110,17 @@ class StorageFileCase(TransactionComponentCase):
             stfile.url, f"https://foo.com/baz/test-of-my_file-{stfile.id}.txt"
         )
 
+    def test_url_external_no_base_url_falls_back_to_odoo(self):
+        """External backend w/o base_url uses the internal Odoo route."""
+        stfile = self._create_storage_file()
+        params = self.env["ir.config_parameter"].sudo()
+        base_url = params.get_param("web.base.url")
+        stfile.backend_id.update({"served_by": "external", "base_url": ""})
+        self.assertEqual(
+            stfile.url,
+            f"{base_url}/storage.file/test-of-my_file-{stfile.id}.txt",
+        )
+
     def test_url_without_base_url(self):
         stfile = self._create_storage_file()
         # served by odoo

--- a/storage_file/tests/test_storage_file.py
+++ b/storage_file/tests/test_storage_file.py
@@ -7,6 +7,7 @@ from unittest import mock
 from urllib import parse
 
 from odoo.exceptions import AccessError, UserError
+from odoo.tests import Form
 
 from odoo.addons.component.tests.common import TransactionComponentCase
 
@@ -317,3 +318,23 @@ class StorageFileCase(TransactionComponentCase):
         # get_url is called on new records
         empty = self.env["storage.file"].new({})._get_url()
         self.assertEqual(empty, "")
+
+    def test_default_backend_id_on_form(self):
+        """Form pre-fills the default backend for storage.file."""
+        form = Form(self.env["storage.file"])
+        self.assertEqual(form.backend_id, self.backend)
+
+    def test_default_backend_id_from_param(self):
+        """storage.file.backend_id param overrides the form default."""
+        other_backend = self.env["storage.backend"].create(
+            {
+                "name": "Other",
+                "backend_type": "filesystem",
+                "filename_strategy": "name_with_id",
+            }
+        )
+        self.env["ir.config_parameter"].sudo().set_param(
+            "storage.file.backend_id", str(other_backend.id)
+        )
+        form = Form(self.env["storage.file"])
+        self.assertEqual(form.backend_id, other_backend)

--- a/storage_file/views/storage_backend_view.xml
+++ b/storage_file/views/storage_backend_view.xml
@@ -17,6 +17,16 @@
                 </div>
                 <field name="is_public" />
                 <field name="base_url" invisible="served_by != 'external'" />
+                <div
+                    class="alert alert-warning"
+                    role="alert"
+                    invisible="served_by != 'external' or base_url"
+                >
+                    <strong>Note:</strong> Without a CDN base URL, files will be proxied
+                    through Odoo. This is acceptable for internal use with low traffic
+                    but suboptimal for high-volume public access as every request loads
+                    the file from the storage backend into memory.
+                </div>
                 <field name="filename_strategy" />
                 <field name="backend_view_use_internal_url" />
             </field>

--- a/storage_file/views/storage_backend_view.xml
+++ b/storage_file/views/storage_backend_view.xml
@@ -15,7 +15,7 @@
                     <br />Make sure this parameter is properly configured and accessible
                     from everwhere you want to access the service.
                 </div>
-                <field name="is_public" invisible="served_by != 'odoo'" />
+                <field name="is_public" />
                 <field name="base_url" invisible="served_by != 'external'" />
                 <field name="filename_strategy" />
                 <field name="backend_view_use_internal_url" />

--- a/storage_file/views/storage_file_view.xml
+++ b/storage_file/views/storage_file_view.xml
@@ -8,6 +8,7 @@
                 <field name="backend_id" />
                 <field name="file_size" />
                 <field name="file_type" />
+                <field name="is_public" optional="hide" />
                 <field name="company_id" groups="base.group_multi_company" />
             </list>
         </field>
@@ -29,6 +30,7 @@
                         <field name="checksum" readonly="True" />
                         <field name="relative_path" readonly="True" />
                         <field name="file_type" />
+                        <field name="is_public" readonly="True" />
                         <field name="company_id" groups="base.group_multi_company" />
                     </group>
                 </div>
@@ -42,6 +44,17 @@
                 <field name="name" />
                 <field name="backend_id" />
                 <field name="url" />
+                <separator />
+                <filter
+                    string="Public"
+                    name="public"
+                    domain="[('is_public', '=', True)]"
+                />
+                <filter
+                    string="Private"
+                    name="private"
+                    domain="[('is_public', '=', False)]"
+                />
             </search>
         </field>
     </record>

--- a/storage_file/views/storage_file_view.xml
+++ b/storage_file/views/storage_file_view.xml
@@ -55,6 +55,13 @@
                     name="private"
                     domain="[('is_public', '=', False)]"
                 />
+                <group string="Group By" expand="0">
+                    <filter
+                        string="Backend"
+                        name="group_by_backend"
+                        context="{'group_by': 'backend_id'}"
+                    />
+                </group>
             </search>
         </field>
     </record>

--- a/storage_image/models/storage_image_relation_abstract.py
+++ b/storage_image/models/storage_image_relation_abstract.py
@@ -23,3 +23,4 @@ class ImageRelationAbstract(models.AbstractModel):
     image_name = fields.Char(related="image_id.name")
     image_alt_name = fields.Char(related="image_id.alt_name")
     image_url = fields.Char(related="image_id.image_medium_url")
+    is_public = fields.Boolean(related="image_id.file_id.is_public", readonly=True)

--- a/storage_image/models/storage_image_relation_abstract.py
+++ b/storage_image/models/storage_image_relation_abstract.py
@@ -24,3 +24,4 @@ class ImageRelationAbstract(models.AbstractModel):
     image_alt_name = fields.Char(related="image_id.alt_name")
     image_url = fields.Char(related="image_id.image_medium_url")
     is_public = fields.Boolean(related="image_id.file_id.is_public", readonly=True)
+    active = fields.Boolean(related="image_id.active", readonly=True)

--- a/storage_image/tests/__init__.py
+++ b/storage_image/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import common
 from . import test_storage_image
 from . import test_storage_replace_file
+from . import test_is_public

--- a/storage_image/tests/__init__.py
+++ b/storage_image/tests/__init__.py
@@ -2,3 +2,4 @@ from . import common
 from . import test_storage_image
 from . import test_storage_replace_file
 from . import test_swap_backend
+from . import test_is_public

--- a/storage_image/tests/test_is_public.py
+++ b/storage_image/tests/test_is_public.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Camptocamp SA
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from .common import StorageImageCommonCase
+
+
+class TestStorageImageIsPublic(StorageImageCommonCase):
+    def setUp(self):
+        super().setUp()
+        self.storage_image = self._create_storage_image_from_file(
+            "static/akretion-logo.png"
+        )
+
+    def test_is_public_reflects_backend(self):
+        self.assertFalse(self.storage_image.is_public)
+        self.backend.sudo().is_public = True
+        self.storage_image.invalidate_recordset(["is_public"])
+        self.assertTrue(self.storage_image.is_public)
+
+    def test_is_public_search(self):
+        self.backend.sudo().is_public = True
+        result = self.env["storage.image"].search(
+            [("is_public", "=", True), ("id", "=", self.storage_image.id)]
+        )
+        self.assertIn(self.storage_image, result)

--- a/storage_image/tests/test_is_public.py
+++ b/storage_image/tests/test_is_public.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Camptocamp SA
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from .common import StorageImageCommonCase
+
+
+class TestStorageImageIsPublic(StorageImageCommonCase):
+    def setUp(self):
+        super().setUp()
+        self.storage_image = self._create_storage_image_from_file(
+            "static/akretion-logo.png"
+        )
+
+    def test_is_public_reflects_backend(self):
+        self.assertFalse(self.storage_image.is_public)
+        self.backend.sudo().is_public = True
+        self.assertTrue(self.storage_image.is_public)
+
+    def test_is_public_search(self):
+        self.backend.sudo().is_public = True
+        result = self.env["storage.image"].search(
+            [("is_public", "=", True), ("id", "=", self.storage_image.id)]
+        )
+        self.assertEqual(self.storage_image, result)

--- a/storage_image/tests/test_storage_image.py
+++ b/storage_image/tests/test_storage_image.py
@@ -115,3 +115,27 @@ class StorageImageCase(StorageImageCommonCase):
                 "&w=64&h=64&mode=fill&fmt=webp",
                 urls,
             )
+
+    def test_default_backend_id_on_form(self):
+        """Creating an image without backend_id uses the configured default."""
+        image = self._create_storage_image(self.filename, self.filedata)
+        self.assertEqual(image.backend_id, self.backend)
+
+    def test_default_backend_id_from_param(self):
+        """storage.image.backend_id param overrides backend on create."""
+        other_backend = (
+            self.env["storage.backend"]
+            .sudo()
+            .create(
+                {
+                    "name": "Image Backend",
+                    "backend_type": "filesystem",
+                    "filename_strategy": "name_with_id",
+                }
+            )
+        )
+        self.env["ir.config_parameter"].sudo().set_param(
+            "storage.image.backend_id", str(other_backend.id)
+        )
+        image = self._create_storage_image(self.filename, self.filedata)
+        self.assertEqual(image.backend_id.id, other_backend.id)

--- a/storage_image/views/storage_image.xml
+++ b/storage_image/views/storage_image.xml
@@ -40,6 +40,7 @@
                 <notebook>
                     <page name="info" string="File Informations">
                         <group name="info">
+                            <field name="backend_id" />
                             <field name="file_id" readonly="True" required="False" />
                             <field name="thumb_medium_id" />
                             <field name="thumb_small_id" />

--- a/storage_image/views/storage_image.xml
+++ b/storage_image/views/storage_image.xml
@@ -8,6 +8,7 @@
                 <field name="name" />
                 <field name="alt_name" />
                 <field name="human_file_size" />
+                <field name="is_public" optional="hide" />
             </list>
         </field>
     </record>
@@ -86,6 +87,17 @@
         <field name="arch" type="xml">
             <search string="Image">
                 <field name="name" />
+                <separator />
+                <filter
+                    string="Public"
+                    name="public"
+                    domain="[('is_public', '=', True)]"
+                />
+                <filter
+                    string="Private"
+                    name="private"
+                    domain="[('is_public', '=', False)]"
+                />
             </search>
         </field>
     </record>

--- a/storage_image/views/storage_image.xml
+++ b/storage_image/views/storage_image.xml
@@ -88,6 +88,7 @@
         <field name="arch" type="xml">
             <search string="Image">
                 <field name="name" />
+                <field name="backend_id" />
                 <separator />
                 <filter
                     string="Public"
@@ -99,6 +100,13 @@
                     name="private"
                     domain="[('is_public', '=', False)]"
                 />
+                <group string="Group By" expand="0">
+                    <filter
+                        string="Backend"
+                        name="group_by_backend"
+                        context="{'group_by': 'backend_id'}"
+                    />
+                </group>
             </search>
         </field>
     </record>

--- a/storage_image_product/views/storage_image.xml
+++ b/storage_image_product/views/storage_image.xml
@@ -7,11 +7,17 @@
             <page name="info" position="before">
                 <page name="products" string="Products">
                     <field name="product_relation_ids" mode="list,form,kanban">
-                        <list>
+                        <list
+                            decoration-success="is_public and active"
+                            decoration-danger="not is_public and active"
+                            decoration-muted="not active"
+                        >
                             <field name="product_tmpl_id" />
                             <field name="available_attribute_value_ids" invisible="1" />
                             <field name="attribute_value_ids" widget="many2many_tags" />
                             <field name="tag_id" />
+                            <field name="is_public" optional="hide" />
+                            <field name="active" column_invisible="True" />
                         </list>
                         <form>
                             <group>
@@ -27,9 +33,15 @@
                 </page>
                 <page name="categories" string="Categories">
                     <field name="category_relation_ids" mode="list,form,kanban">
-                        <list>
+                        <list
+                            decoration-success="is_public and active"
+                            decoration-danger="not is_public and active"
+                            decoration-muted="not active"
+                        >
                             <field name="category_id" />
                             <field name="tag_id" />
+                            <field name="is_public" optional="hide" />
+                            <field name="active" column_invisible="True" />
                         </list>
                         <form>
                             <group>

--- a/storage_media/tests/__init__.py
+++ b/storage_media/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_storage_media
 from . import test_storage_replace_file
+from . import test_is_public

--- a/storage_media/tests/__init__.py
+++ b/storage_media/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_storage_media
 from . import test_storage_replace_file
 from . import test_swap_backend
+from . import test_is_public

--- a/storage_media/tests/test_is_public.py
+++ b/storage_media/tests/test_is_public.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Camptocamp SA
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.addons.component.tests.common import TransactionComponentCase
+
+
+class TestStorageMediaIsPublic(TransactionComponentCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.backend = cls.env.ref("storage_backend.default_storage_backend")
+
+    def setUp(self):
+        super().setUp()
+        self.media = self.env["storage.media"].create(
+            {"name": "test-media.txt", "backend_id": self.backend.id}
+        )
+
+    def test_is_public_reflects_backend(self):
+        self.backend.sudo().is_public = False
+        self.media.invalidate_recordset(["is_public"])
+        self.assertFalse(self.media.is_public)
+        self.backend.sudo().is_public = True
+        self.media.invalidate_recordset(["is_public"])
+        self.assertTrue(self.media.is_public)
+
+    def test_is_public_search(self):
+        self.backend.sudo().is_public = True
+        result = self.env["storage.media"].search(
+            [("is_public", "=", True), ("id", "=", self.media.id)]
+        )
+        self.assertIn(self.media, result)

--- a/storage_media/tests/test_is_public.py
+++ b/storage_media/tests/test_is_public.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Camptocamp SA
+# @author Simone Orsi <simone.orsi@camptocamp.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.addons.component.tests.common import TransactionComponentCase
+
+
+class TestStorageMediaIsPublic(TransactionComponentCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.backend = cls.env.ref("storage_backend.default_storage_backend")
+        cls.media = cls.env["storage.media"].create(
+            {"name": "test-media.txt", "backend_id": cls.backend.id}
+        )
+
+    def test_is_public_reflects_backend(self):
+        self.backend.sudo().is_public = False
+        self.assertFalse(self.media.is_public)
+        self.backend.sudo().is_public = True
+        self.assertTrue(self.media.is_public)
+
+    def test_is_public_search(self):
+        self.backend.sudo().is_public = True
+        result = self.env["storage.media"].search(
+            [("is_public", "=", True), ("id", "=", self.media.id)]
+        )
+        self.assertEqual(self.media, result)

--- a/storage_media/tests/test_storage_media.py
+++ b/storage_media/tests/test_storage_media.py
@@ -34,3 +34,23 @@ class StorageMediaCase(TransactionComponentCase):
         media.unlink()
         self.assertEqual(stfile.to_delete, True)
         self.assertEqual(stfile.active, False)
+
+    def test_default_backend_id_on_form(self):
+        """Creating a media without backend_id uses the configured default."""
+        media = self.env["storage.media"].create({"name": "default-test.txt"})
+        self.assertEqual(media.backend_id, self.backend)
+
+    def test_default_backend_id_from_param(self):
+        """storage.media.backend_id param overrides backend on create."""
+        other_backend = self.env["storage.backend"].create(
+            {
+                "name": "Media Backend",
+                "backend_type": "filesystem",
+                "filename_strategy": "name_with_id",
+            }
+        )
+        self.env["ir.config_parameter"].sudo().set_param(
+            "storage.media.backend_id", str(other_backend.id)
+        )
+        media = self.env["storage.media"].create({"name": "test.txt"})
+        self.assertEqual(media.backend_id.id, other_backend.id)

--- a/storage_media/views/storage_media_view.xml
+++ b/storage_media/views/storage_media_view.xml
@@ -34,6 +34,7 @@
                         <field name="url" readonly="True" widget="url" />
                         <field name="name" />
                         <field name="media_type_id" />
+                        <field name="backend_id" />
                     </group>
                 </sheet>
             </form>

--- a/storage_media/views/storage_media_view.xml
+++ b/storage_media/views/storage_media_view.xml
@@ -6,6 +6,7 @@
             <list decoration-muted="not active">
                 <field name="name" />
                 <field name="media_type_id" />
+                <field name="is_public" optional="hide" />
             </list>
         </field>
     </record>
@@ -46,7 +47,19 @@
             <search string="Storage Media">
                 <field name="name" />
                 <field name="media_type_id" />
+                <field name="backend_id" />
                 <field name="url" />
+                <separator />
+                <filter
+                    string="Public"
+                    name="public"
+                    domain="[('is_public', '=', True)]"
+                />
+                <filter
+                    string="Private"
+                    name="private"
+                    domain="[('is_public', '=', False)]"
+                />
                 <separator />
                 <filter
                     string="All"
@@ -59,6 +72,13 @@
                     name="inactive"
                     domain="[('active', '=', False)]"
                 />
+                <group string="Group By" expand="0">
+                    <filter
+                        string="Backend"
+                        name="group_by_backend"
+                        context="{'group_by': 'backend_id'}"
+                    />
+                </group>
             </search>
         </field>
     </record>

--- a/storage_media_product/models/product.py
+++ b/storage_media_product/models/product.py
@@ -65,6 +65,7 @@ class ProductMediaRelation(models.Model):
     url = fields.Char(related="media_id.url", readonly=True)
     url_path = fields.Char(related="media_id.url_path", readonly=True)
     media_type_id = fields.Many2one(related="media_id.media_type_id", readonly=True)
+    is_public = fields.Boolean(related="media_id.file_id.is_public", readonly=True)
 
     @api.depends("media_id", "product_tmpl_id.attribute_line_ids.value_ids")
     def _compute_available_attribute(self):

--- a/storage_media_product/models/product.py
+++ b/storage_media_product/models/product.py
@@ -66,6 +66,7 @@ class ProductMediaRelation(models.Model):
     url_path = fields.Char(related="media_id.url_path", readonly=True)
     media_type_id = fields.Many2one(related="media_id.media_type_id", readonly=True)
     is_public = fields.Boolean(related="media_id.file_id.is_public", readonly=True)
+    active = fields.Boolean(related="media_id.active", readonly=True)
 
     @api.depends("media_id", "product_tmpl_id.attribute_line_ids.value_ids")
     def _compute_available_attribute(self):

--- a/storage_media_product/views/product.xml
+++ b/storage_media_product/views/product.xml
@@ -26,6 +26,7 @@
                         widget="many2many_tags"
                         invisible="not available_attribute_value_ids"
                     />
+                    <field name="is_public" />
                 </group>
             </form>
         </field>

--- a/storage_media_product/views/product.xml
+++ b/storage_media_product/views/product.xml
@@ -35,9 +35,15 @@
     <record id="product_media_relation_tree" model="ir.ui.view">
         <field name="model">product.media.relation</field>
         <field name="arch" type="xml">
-            <list>
+            <list
+                decoration-success="is_public and active"
+                decoration-danger="not is_public and active"
+                decoration-muted="not active"
+            >
                 <field name="media_id" />
                 <field name="media_type_id" readonly="True" />
+                <field name="is_public" optional="hide" />
+                <field name="active" column_invisible="True" />
             </list>
         </field>
     </record>

--- a/storage_thumbnail/tests/test_thumbnail.py
+++ b/storage_thumbnail/tests/test_thumbnail.py
@@ -33,7 +33,7 @@ class TestStorageThumbnail(TransactionComponentCase):
 
     def _create_thumbnail(self):
         # create thumbnail
-        vals = {"name": "TEST THUMB"}
+        vals = {"name": "TEST THUMB", "data": self.filedata}
         return self.env["storage.thumbnail"].create(vals)
 
     def _create_image(self, resize=False, **kw):


### PR DESCRIPTION
Improve handling of storage backend visibility and allow serving private files directly through Odoo.

Changes summary:

## storage_file

* Serve private files stored on external backends (S3, etc.) directly via the Odoo controller, removing the need for a private CDN with complex authentication. When an external backend has no base_url, the file URL falls back to the `/storage.file/<slug>` route.
* Use record rules to control file access: public users can only read files on public backends; internal users can read all files.
* Make `backend_id` editable on forms with a pre-loaded default (configurable via ir.config_parameter).
* Make is_public visible on the backend form regardless of served_by type.
* Add search filter for public/private files.

## storage_image / storage_media

- Add search filter for public/private.
- Make backend_id visible (readonly) on forms with a configurable default.

## storage_media_product:

- Show is_public on the product media view


NOTE: as the backend is now editable, the best is to use #622 to take care of swapping backends on change.