### PR TITLE
[19.0][IMP] fs_folder: Disable FsFolderItem clicks while processing

### DIFF
--- a/fs_folder/static/src/fs_folder/fs_folder.esm.js
+++ b/fs_folder/static/src/fs_folder/fs_folder.esm.js
@@ -22,7 +22,14 @@ export class FsFolder extends Component {
         this.dropzone = useRef("dropzone");
         this.dialog = useService("dialog");
         this.fileViewer = usePreviewIframeViewer();
-        this.state = useState({path: [], data: [], copy: false, sort: [], hide: []});
+        this.state = useState({
+            path: [],
+            data: [],
+            copy: false,
+            sort: [],
+            hide: [],
+            isItemActionProcessing: false,
+        });
         this.notificationService = useService("fs_folder_notification");
         useBus(this.notificationService.bus, "folder_modified", this.onFolderModified);
         useEffect(
@@ -36,16 +43,25 @@ export class FsFolder extends Component {
         );
         useDropzone(this.dropzone, this.onDropFile.bind(this), "");
         useSubEnv({
-            onClickDirectory: (record) => {
-                this.onClickDirectory(record);
-            },
-            onClickPreview: (record) => {
-                this.onClickPreview(record);
-            },
-            onClickDownload: (record) => {
-                this.onClickDownload(record);
-            },
+            onClickDirectory: (record) =>
+                this.withItemActionLock(() => this.onClickDirectory(record)),
+            onClickPreview: (record) =>
+                this.withItemActionLock(() => this.onClickPreview(record)),
+            onClickDownload: (record) =>
+                this.withItemActionLock(() => this.onClickDownload(record)),
+            onRunItemAction: (callback) => this.withItemActionLock(callback),
         });
+    }
+    async withItemActionLock(callback) {
+        if (this.state.isItemActionProcessing) {
+            return;
+        }
+        this.state.isItemActionProcessing = true;
+        try {
+            return await callback();
+        } finally {
+            this.state.isItemActionProcessing = false;
+        }
     }
     onFolderModified(event) {
         const {resId, resModel, fieldName} = event.detail;
@@ -224,7 +240,7 @@ export class FsFolder extends Component {
     }
     async onClickDirectory(record) {
         this.state.path = [...this.state.path, record.name];
-        this.setData();
+        await this.setData();
     }
     async onClickDownload(record) {
         await downloadFile(

--- a/fs_folder/static/src/fs_folder/fs_folder.scss
+++ b/fs_folder/static/src/fs_folder/fs_folder.scss
@@ -1,5 +1,8 @@
 .o_field_fs_folder {
     width: 100%;
+    .o_fs_folder_item_actions_locked {
+        pointer-events: none;
+    }
     .o_fs_folder_clickable {
         cursor: pointer;
     }

--- a/fs_folder/static/src/fs_folder/fs_folder.xml
+++ b/fs_folder/static/src/fs_folder/fs_folder.xml
@@ -144,7 +144,9 @@
                         </th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody
+                    t-att-class="state.isItemActionProcessing ? 'o_fs_folder_item_actions_locked' : ''"
+                >
                     <t t-foreach="state.data" t-as="record" t-key="record.name">
                         <FsFolderItem
                             record="record"

--- a/fs_folder/static/src/fs_folder/fs_folder_item/fs_folder_item.esm.js
+++ b/fs_folder/static/src/fs_folder/fs_folder_item/fs_folder_item.esm.js
@@ -22,11 +22,11 @@ export class FsFolderItem extends Component {
                 return a.sequence < b.sequence ? -1 : 1;
             });
     }
-    onClick() {
+    async onClick() {
         if (this.props.record.type === "directory") {
-            this.env.onClickDirectory(this.props.record);
+            await this.env.onClickDirectory(this.props.record);
         } else {
-            this.env.onClickPreview(this.props.record);
+            await this.env.onClickPreview(this.props.record);
         }
     }
 }

--- a/fs_folder/static/src/fs_folder/fs_folder_item/fs_folder_item.xml
+++ b/fs_folder/static/src/fs_folder/fs_folder_item/fs_folder_item.xml
@@ -41,7 +41,7 @@
                         <t t-foreach="items" t-as="item" t-key="item_index">
                             <DropdownItem
                                 class="item.class_name"
-                                onSelected="() => item.callback(this.props.record)"
+                                onSelected="() => this.env.onRunItemAction(() => item.callback(this.props.record))"
                                 t-on-pointerdown.prevent="() => {}"
                             >
                                 <i


### PR DESCRIPTION
## Summary
Fix race conditions in FsFolder by preventing overlapping FsFolderItem actions from rapid clicks. 

<img width="1207" height="353" alt="image" src="https://github.com/user-attachments/assets/10c5ab3e-b072-45a3-905a-c3c6c03c6345" />

## What changed 
- Added a single in-flight lock in FsFolder state. 
- Routed item actions through the parent lock so only one action runs at a time. 
- Released the lock in all cases (success or failure). 

## Result 
- No duplicate item actions from double/rapid clicks. 
- View interaction is restored reliably after each action. 


