### PR TITLE
[18.0][FIX] tests: pin aiohttp<3.12 for S3 VCR tests

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,6 @@ vcrpy-unittest
 s3fs>=2025.3.0
 pyOpenSSL<24
 cryptography<43
+# S3 test suite importing vcr’s aiohttp stubs
+# require aiohttp version with AsyncStreamReaderMixin.
+aiohttp<3.12


### PR DESCRIPTION
Extracted from #622 (failing on 18.0 too)