### PR TITLE
[18.0][FIX] storage_backend_s3: reduce test log noise

### DIFF
--- a/storage_backend_s3/tests/test_amazon_s3.py
+++ b/storage_backend_s3/tests/test_amazon_s3.py
@@ -15,6 +15,9 @@ from odoo.addons.storage_backend.tests.common import BackendStorageTestMixin, Co
 
 _logger = logging.getLogger(__name__)
 
+# avoid bloating logs with vcr debug info, which can be very large for S3 tests
+logging.getLogger("vcr.cassette").setLevel(logging.WARNING)
+
 
 class AmazonS3Case(VCRMixin, CommonCase, BackendStorageTestMixin):
     def _get_vcr_kwargs(self, **kwargs):


### PR DESCRIPTION
Avoid bloating logs like

<img width="1960" height="351" alt="image" src="https://github.com/user-attachments/assets/4bac54ad-fa48-4953-ac13-5f5d84c0af2d" />
