### PR TITLE
[19.0][FIX] fs_attachment: error on http stream

### DIFF
--- a/fs_attachment/fs_stream.py
+++ b/fs_attachment/fs_stream.py
@@ -2,9 +2,12 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from odoo.http import STATIC_CACHE_LONG, Response, Stream, request
 
-from .models.ir_attachment import IrAttachment
+if TYPE_CHECKING:
+    from .models.ir_attachment import IrAttachment
 
 try:
     from werkzeug.utils import secure_filename

--- a/fs_attachment/models/ir_attachment.py
+++ b/fs_attachment/models/ir_attachment.py
@@ -22,6 +22,7 @@ from odoo import api, fields, models
 from odoo.exceptions import AccessError, UserError
 from odoo.fields import Domain
 
+from ..fs_stream import FsStream
 from .strtobool import strtobool
 
 _logger = logging.getLogger(__name__)
@@ -369,6 +370,12 @@ class IrAttachment(models.Model):
     def _set_attachment_data(self, asbytes) -> None:  # pylint: disable=missing-return
         super()._set_attachment_data(asbytes)
         self._enforce_meaningful_storage_filename()
+
+    def _to_http_stream(self):
+        self.ensure_one()
+        if self.fs_filename:
+            return FsStream.from_fs_attachment(self)
+        return super()._to_http_stream()
 
     ##############################################
     # Internal methods to use the object storage #

--- a/fs_attachment/tests/test_stream.py
+++ b/fs_attachment/tests/test_stream.py
@@ -96,6 +96,17 @@ class TestStream(HttpCaseWithUserDemo):
             self.assertEqual(res.content, assert_content, "Wong content")
         return res
 
+    def test_to_http_stream(self):
+        from ..fs_stream import FsStream
+
+        stream = self.attachment_binary._to_http_stream()
+        self.assertIsInstance(stream, FsStream)
+        self.assertEqual(stream.mimetype, "text/plain")
+
+        stream = self.attachment_image._to_http_stream()
+        self.assertIsInstance(stream, FsStream)
+        self.assertEqual(stream.mimetype, "image/png")
+
     def test_content_url(self):
         self.authenticate("admin", "admin")
         url = f"/web/content/{self.attachment_binary.id}"


### PR DESCRIPTION
This fix is intended to fix #631 

Noticed the error when trying to load /doc endpoint

Changes are:
- super of _to_http_stream on ir.attachment
- small retouch on imports for preventing circular importing
- tests