### PR TITLE
[19.0][IMP] fs_attachments: fix parsing of stored filenames when storing locally

### DIFF
--- a/fs_attachment/models/ir_attachment.py
+++ b/fs_attachment/models/ir_attachment.py
@@ -518,11 +518,15 @@ class IrAttachment(models.Model):
         :param fname: the fname to parse
         :param base: if True, return the base filesystem
         """
-        partition = fname.partition("://")
-        storage_code = partition[0]
-        fs = self._get_fs_storage_for_code(storage_code)
-        fname = partition[2]
-        return fs, storage_code, fname
+        storage_code = None
+        fs = None
+        file_name = fname
+        if "://" in fname:
+            partition = fname.partition("://")
+            storage_code = partition[0]
+            fs = self._get_fs_storage_for_code(storage_code)
+            file_name = partition[2]
+        return fs, storage_code, file_name
 
     @api.model
     def _parse_fs_filename(self, filename: str) -> tuple[str, int, int, str] | None:

--- a/fs_attachment/tests/test_fs_attachment.py
+++ b/fs_attachment/tests/test_fs_attachment.py
@@ -11,6 +11,28 @@ from .common import MyException, TestFSAttachmentCommon
 
 
 class TestFSAttachment(TestFSAttachmentCommon):
+    def test_fs_parse_store_fname(self):
+        raw_fname = "fc/fcc92eb498d207046dcf79f50badd1041535626c"
+        fs, storage_code, file_name = self.ir_attachment_model._fs_parse_store_fname(
+            raw_fname
+        )
+        self.assertFalse(fs)
+        self.assertFalse(storage_code)
+        self.assertEqual(file_name, raw_fname)
+
+    @mock.patch(
+        "odoo.addons.fs_storage.models.fs_storage.FSStorage.get_fs_by_code",
+        return_value="FS_MOCK",
+    )
+    def test_fs_parse_store_fname_azure(self, mock_fs_storage):
+        azure_fname = "azure://b1/e9/screenshot-2026-06-30-190529-700499-0.png"
+        fs, storage_code, file_name = self.ir_attachment_model._fs_parse_store_fname(
+            azure_fname
+        )
+        self.assertIs(fs, "FS_MOCK")
+        self.assertEqual(storage_code, "azure")
+        self.assertEqual(file_name, "b1/e9/screenshot-2026-06-30-190529-700499-0.png")
+
     def test_create_attachment_explicit_location(self):
         content = b"This is a test attachment"
         attachment = (


### PR DESCRIPTION
Solves this error when new attachments should be stored locally:
```
RPC_ERROR

Odoo Server Error

Occured on c4a8-18-0-dev-34353123.dev.odoo.com on model hr.expense on 2026-07-03 09:32:36 GMT

Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/http.py", line 2329, in _serve_db
    return service_model.retrying(serve_func, env=self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/service/model.py", line 190, in retrying
    env.cr.flush()  # submit the changes to the database
    ^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/sql_db.py", line 182, in flush
    self.transaction.flush()
  File "/home/odoo/src/odoo/odoo/orm/environments.py", line 592, in flush
    self.default_env.flush_all()
  File "/home/odoo/src/odoo/odoo/orm/environments.py", line 383, in flush_all
    self._recompute_all()
  File "/home/odoo/src/odoo/odoo/orm/environments.py", line 376, in _recompute_all
    self[field.model_name]._recompute_field(field)
  File "/home/odoo/src/odoo/odoo/orm/models.py", line 6960, in _recompute_field
    field.recompute(records)
  File "/home/odoo/src/odoo/odoo/orm/fields.py", line 1891, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/home/odoo/src/odoo/odoo/orm/fields.py", line 1861, in apply_except_missing
    func(records)
  File "/home/odoo/src/odoo/odoo/orm/fields.py", line 1915, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/odoo/orm/models.py", line 4954, in _compute_field_value
    determine(field.compute, self)
  File "/home/odoo/src/odoo/odoo/orm/fields.py", line 81, in determine
    return needle(*args)
           ^^^^^^^^^^^^^
  File "/home/odoo/src/user/modules/oca/storage/fs_attachment/models/ir_attachment.py", line 114, in _compute_fs_url
    new_url = self.env["fs.storage"]._get_url_for_attachment(rec)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/user/modules/oca/storage/fs_attachment/models/fs_storage.py", line 266, in _get_url_for_attachment
    _fs, storage_code, file_path = attachment._get_fs_parts()
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/user/modules/oca/storage/fs_attachment/models/ir_attachment.py", line 597, in _get_fs_parts
    return self._fs_parse_store_fname(self.store_fname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/user/modules/oca/storage/fs_attachment/models/ir_attachment.py", line 527, in _fs_parse_store_fname
    fs = self._get_fs_storage_for_code(storage_code)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/user/modules/oca/storage/fs_attachment/models/ir_attachment.py", line 509, in _get_fs_storage_for_code
    raise SystemError(f"No Filesystem storage for code {code}")
SystemError: No Filesystem storage for code 91/91e790cb58ba34fef3a9c34c15bdef1818b9c82b

The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
    RPCError@https://c4a8-18-0-dev-34353123.dev.odoo.com/web/assets/094bae2/web.assets_web.min.js:3180:78
    makeErrorFromResponse@https://c4a8-18-0-dev-34353123.dev.odoo.com/web/assets/094bae2/web.assets_web.min.js:3184:165
    rpc._rpc/promise</<@https://c4a8-18-0-dev-34353123.dev.odoo.com/web/assets/094bae2/web.assets_web.min.js:3191:34
    
```