### PR TITLE
[IMP] fs_image_*: Defines images in all expected sizes into mixin

### DIFF
--- a/fs_base_multi_image/__manifest__.py
+++ b/fs_base_multi_image/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Fs Base Multi Image",
     "summary": """
         Mulitple Images from External File System""",
-    "version": "16.0.1.1.2",
+    "version": "16.0.2.0.0",
     "license": "AGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/storage",

--- a/fs_base_multi_image/migrations/16.0.2.0.0/end-migrate.py
+++ b/fs_base_multi_image/migrations/16.0.2.0.0/end-migrate.py
@@ -1,0 +1,71 @@
+# Copyright 2026 ACSONE SA/NV (<https://acsone.eu>)
+# Author: Laurent Mignon <laurent.mignon@acsone.eu>
+# pylint: disable=odoo-addons-relative-import
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+from odoo.addons.fs_base_multi_image.models.fs_image_relation_mixin import (
+    FsImageRelationMixin,
+)
+
+try:
+    from odoo.upgrade import util
+except ImportError as err:
+    raise ImportError(
+        "This migration script requires odoo.upgrade.util.\n"
+        "Please install odoo.upgrade.util to proceed with the migration.\n"
+        "See https://github.com/odoo/upgrade-util/"
+    ) from err
+
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    for model_name in env:
+        if isinstance(env[model_name], FsImageRelationMixin):
+            _logger.info("Recomputing image fields for model %s", model_name)
+            # first 'rename attachment for field named image_medium' to 'image_128'
+            _logger.info(
+                "Renaming attachments for field specific_image_medium "
+                "to specific_image_128 for model %s",
+                model_name,
+            )
+            cr.execute(
+                """
+                UPDATE ir_attachment
+                SET res_field = 'specific_image_128'
+                WHERE res_model = %s AND res_field = 'specific_image_medium'
+                """,
+                (model_name,),
+            )
+            cr.execute(
+                """
+                UPDATE ir_attachment
+                SET index_content = 'fs_specific_image_to_recompute'
+                WHERE res_model = %s AND res_field = 'specific_image'
+                """,
+                (model_name,),
+            )
+
+    # The actual recompute of the resized image is expensive and would block
+    # this migration (and the whole `-u` run) if done here synchronously. Defer it to a
+    # background cron that processes small batches
+    util.create_cron(
+        cr,
+        "Recompute fs.image.relation.mixin resized fields",
+        "ir.cron",
+        """
+remaining = env["fs.image.mixin"]._cron_do_migrate_resize_image_fields(
+    index_content="fs_specific_image_to_recompute", res_field="specific_image", batch_size=400
+)
+
+if not remaining:
+    log("All fs.image.relation.mixin resized fields have been recomputed. "
+        "You can safely disable the cron.", level="warning")
+""",
+        interval=(10, "minutes"),
+    )

--- a/fs_base_multi_image/models/fs_image_relation_mixin.py
+++ b/fs_base_multi_image/models/fs_image_relation_mixin.py
@@ -21,7 +21,35 @@ class FsImageRelationMixin(models.AbstractModel):
     )
     specific_image = fs_fields.FSImage("Specific Image")
     # resized fields stored (as attachment) for performance
+
+    # deprecated fields, kept for backward compatibility
+    # uses specific_image_128 instead of specific_image_medium
     specific_image_medium = fs_fields.FSImage(
+        "Specific Image medium",
+        related="specific_image_128",
+    )
+    specific_image_1024 = fs_fields.FSImage(
+        "Specific Image (1024)",
+        related="specific_image",
+        max_width=1024,
+        max_height=1024,
+        store=True,
+    )
+    specific_image_512 = fs_fields.FSImage(
+        "Specific Image (512)",
+        related="specific_image",
+        max_width=512,
+        max_height=512,
+        store=True,
+    )
+    specific_image_256 = fs_fields.FSImage(
+        "Specific Image (256)",
+        related="specific_image",
+        max_width=256,
+        max_height=256,
+        store=True,
+    )
+    specific_image_128 = fs_fields.FSImage(
         "Specific Image (128)",
         related="specific_image",
         max_width=128,
@@ -37,8 +65,21 @@ class FsImageRelationMixin(models.AbstractModel):
         store=False,
     )
     # resized fields stored (as attachment) for performance
-    image_medium = fs_fields.FSImage(
-        "Image (128)", compute="_compute_image_medium", store=False
+
+    # deprecated fields, kept for backward compatibility
+    # uses image_128 instead of image_medium
+    image_medium = fs_fields.FSImage("Image medium", related="image_128", store=False)
+    image_1024 = fs_fields.FSImage(
+        "Image (1024)", compute="_compute_image_1024", store=False
+    )
+    image_512 = fs_fields.FSImage(
+        "Image (512)", compute="_compute_image_512", store=False
+    )
+    image_256 = fs_fields.FSImage(
+        "Image (256)", compute="_compute_image_256", store=False
+    )
+    image_128 = fs_fields.FSImage(
+        "Image (128)", compute="_compute_image_128", store=False
     )
 
     name = fields.Char(compute="_compute_name", store=True, index=True)
@@ -68,13 +109,37 @@ class FsImageRelationMixin(models.AbstractModel):
             else:
                 record.image = record.specific_image
 
-    @api.depends("image_id", "specific_image", "link_existing")
-    def _compute_image_medium(self):
+    @api.depends("image_id", "specific_image_128", "link_existing")
+    def _compute_image_128(self):
         for record in self:
             if record.link_existing:
-                record.image_medium = record.image_id.image_medium
+                record.image_128 = record.image_id.image_128
             else:
-                record.image_medium = record.specific_image_medium
+                record.image_128 = record.specific_image_128
+
+    @api.depends("image_id", "specific_image_256", "link_existing")
+    def _compute_image_256(self):
+        for record in self:
+            if record.link_existing:
+                record.image_256 = record.image_id.image_256
+            else:
+                record.image_256 = record.specific_image_256
+
+    @api.depends("image_id", "specific_image_512", "link_existing")
+    def _compute_image_512(self):
+        for record in self:
+            if record.link_existing:
+                record.image_512 = record.image_id.image_512
+            else:
+                record.image_512 = record.specific_image_512
+
+    @api.depends("image_id", "specific_image_1024", "link_existing")
+    def _compute_image_1024(self):
+        for record in self:
+            if record.link_existing:
+                record.image_1024 = record.image_id.image_1024
+            else:
+                record.image_1024 = record.specific_image_1024
 
     def _inverse_image(self):
         for record in self:

--- a/fs_base_multi_image/views/fs_image_relation_mixin.xml
+++ b/fs_base_multi_image/views/fs_image_relation_mixin.xml
@@ -12,14 +12,14 @@
                      <field
                         name="image"
                         class="oe_avatar"
-                        options="{'preview_image': 'image_medium', 'zoom': true}"
+                        options="{'preview_image': 'image_128', 'zoom': true}"
                         readonly="1"
                         attrs="{'invisible': [('link_existing', '=', False)]}"
                     />
                     <field
                         name="specific_image"
                         class="oe_avatar"
-                        options="{'preview_image': 'image_medium', 'zoom': true}"
+                        options="{'preview_image': 'image_128', 'zoom': true}"
                         attrs="{'invisible': [('link_existing', '=', True)]}"
                     />
                     <group>

--- a/fs_image/__manifest__.py
+++ b/fs_image/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Fs Image",
     "summary": """
         Field to store images into filesystem storages""",
-    "version": "16.0.1.0.5",
+    "version": "16.0.2.0.0",
     "license": "AGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/storage",

--- a/fs_image/migrations/16.0.2.0.0/end-migrate.py
+++ b/fs_image/migrations/16.0.2.0.0/end-migrate.py
@@ -1,0 +1,68 @@
+# Copyright 2026 ACSONE SA/NV (<https://acsone.eu>)
+# Author: Laurent Mignon <laurent.mignon@acsone.eu>
+# pylint: disable=odoo-addons-relative-import
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+from odoo.addons.fs_image.models.fs_image_mixin import FSImageMixin
+
+try:
+    from odoo.upgrade import util
+except ImportError as err:
+    raise ImportError(
+        "This migration script requires odoo.upgrade.util.\n"
+        "Please install odoo.upgrade.util to proceed with the migration.\n"
+        "See https://github.com/odoo/upgrade-util/"
+    ) from err
+
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    for model_name in env:
+        if isinstance(env[model_name], FSImageMixin):
+            _logger.info("Recomputing image fields for model %s", model_name)
+            # first 'rename attachment for field named image_medium' to 'image_128'
+            _logger.info(
+                "Renaming attachments for field image_medium to image_128 for model %s",
+                model_name,
+            )
+            cr.execute(
+                """
+                UPDATE ir_attachment
+                SET res_field = 'image_128'
+                WHERE res_model = %s AND res_field = 'image_medium'
+                """,
+                (model_name,),
+            )
+            cr.execute(
+                """
+                UPDATE ir_attachment
+                SET index_content = 'fs_image_to_recompute'
+                WHERE res_model = %s AND res_field = 'image'
+                """,
+                (model_name,),
+            )
+
+    # The actual recompute of the resized image is expensive and would block
+    # this migration (and the whole `-u` run) if done here synchronously. Defer it to a
+    # background cron that processes small batches.
+    util.create_cron(
+        cr,
+        "Recompute fs.image.mixin resized fields",
+        "ir.cron",
+        """
+remaining = env["fs.image.mixin"]._cron_do_migrate_resize_image_fields(
+    index_content="fs_image_to_recompute", res_field="image", batch_size=400
+)
+if not remaining:
+    log("All fs.image.mixin resized fields have been recomputed. "
+        "You can safely disable the cron.", level="warning")
+""",
+        interval=(10, "minutes"),
+    )

--- a/fs_image/models/fs_image_mixin.py
+++ b/fs_image/models/fs_image_mixin.py
@@ -1,9 +1,12 @@
 # Copyright 2023 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import logging
 
-from odoo import models
+from odoo import api, models
 
 from ..fields import FSImage
+
+_logger = logging.getLogger(__name__)
 
 
 class FSImageMixin(models.AbstractModel):
@@ -12,6 +15,72 @@ class FSImageMixin(models.AbstractModel):
 
     image = FSImage("Image")
     # resized fields stored (as attachment) for performance
-    image_medium = FSImage(
-        "Image medium", related="image", max_width=128, max_height=128, store=True
+
+    # deprecated fields, kept for backward compatibility
+    # uses specific_image_128 instead of specific_image_medium
+    image_medium = FSImage("Image medium", related="image_128", store=False)
+
+    image_1024 = FSImage(
+        "Image 1024", related="image", max_width=1024, max_height=1024, store=True
     )
+    image_512 = FSImage(
+        "Image 512", related="image", max_width=512, max_height=512, store=True
+    )
+    image_256 = FSImage(
+        "Image 256", related="image", max_width=256, max_height=256, store=True
+    )
+    image_128 = FSImage(
+        "Image 128", related="image", max_width=128, max_height=128, store=True
+    )
+
+    @api.model
+    def _cron_do_migrate_resize_image_fields(
+        self, index_content, res_field, batch_size=100
+    ):
+        """Migrate image fields to the new FSImage fields.
+
+        This method is designed to be called from a cron job to process image fields
+        in batches when migrating from 1.X to 2.x where the image_medium field has
+        been renamed to image_128 and new resized fields have been added.
+        It processes a batch of images, resizes them, and updates their
+        index_content to indicate that they have been resized.
+        """
+        fs_images_to_resize = self.env["ir.attachment"].search(
+            [("index_content", "=", index_content), ("res_field", "=", res_field)],
+            limit=batch_size + 1,
+            order="write_date desc",
+        )
+        remaining = len(fs_images_to_resize) > batch_size
+
+        images_to_resize = fs_images_to_resize[:batch_size]
+        image_resized = self.env["ir.attachment"].browse()
+
+        ids_by_model = {}
+        for image in images_to_resize:
+            if image.res_model not in ids_by_model:
+                ids_by_model[image.res_model] = []
+            try:
+                if (
+                    not image.with_prefetch([image.id])
+                    .with_context(bin_size=True)
+                    .datas
+                ):
+                    image.index_content = "no content"
+                    continue
+            except Exception:  # noqa: E722
+                _logger.exception(
+                    "Failed to read image %s for model %s", image.id, image.res_model
+                )
+                image.index_content = "to verify"
+                continue
+            ids_by_model[image.res_model].append(image.res_id)
+            image_resized |= image
+
+        for res_model, ids in ids_by_model.items():
+            res_model = self.env[res_model]
+            records = res_model.browse(ids)
+            records.modified([res_field])
+
+        image_resized.write({"index_content": f"{index_content}_resized"})
+        self.env.flush_all()
+        return remaining

--- a/fs_image/readme/USAGE.rst
+++ b/fs_image/readme/USAGE.rst
@@ -104,7 +104,7 @@ too much bandwidth.
                       <field
                           name="image"
                           class="oe_avatar"
-                          options="{'preview_image': 'image_medium', 'zoom': true}"
+                          options="{'preview_image': 'image_1024', 'zoom': true}"
                       />
                   </group>
               </sheet>

--- a/fs_product_brand_multi_image/views/product_brand.xml
+++ b/fs_product_brand_multi_image/views/product_brand.xml
@@ -16,7 +16,7 @@
                  <field
                     name="image"
                     class="oe_avatar"
-                    options="{'preview_image': 'image_medium', 'zoom': true}"
+                    options="{'preview_image': 'image_1024', 'zoom': true}"
                 />
             </field>
             <notebook position="inside">
@@ -43,7 +43,7 @@
             <xpath expr="//div[hasclass('o_kanban_image')]/img" position="attributes">
                <attribute
                     name="t-att-src"
-                >kanban_image('product.brand', 'image_medium', record.id.raw_value)</attribute>
+                >kanban_image('product.brand', 'image_128', record.id.raw_value)</attribute>
             </xpath>
         </field>
     </record>

--- a/fs_product_multi_image/views/fs_product_category_image.xml
+++ b/fs_product_multi_image/views/fs_product_category_image.xml
@@ -33,7 +33,7 @@
             <xpath expr="//div[hasclass('o_kanban_image')]" position="inside">
                 <div class="o_kanban_image me-1">
                     <img
-                        t-att-src="kanban_image('fs.product.category.image', 'image_medium', record.id.raw_value)"
+                        t-att-src="kanban_image('fs.product.category.image', 'image_128', record.id.raw_value)"
                         t-if="record.id"
                         alt="Image"
                         class="o_image_64_contain"

--- a/fs_product_multi_image/views/fs_product_image.xml
+++ b/fs_product_multi_image/views/fs_product_image.xml
@@ -44,7 +44,7 @@
             <xpath expr="//div[hasclass('o_kanban_image')]" position="inside">
                 <div class="o_kanban_image me-1">
                     <img
-                        t-att-src="kanban_image('fs.product.image', 'image_medium', record.id.raw_value)"
+                        t-att-src="kanban_image('fs.product.image', 'image_128', record.id.raw_value)"
                         t-if="record.id"
                         alt="Image"
                         class="o_image_64_contain"

--- a/fs_product_multi_image/views/product_category.xml
+++ b/fs_product_multi_image/views/product_category.xml
@@ -13,7 +13,7 @@
                 <field
                     name="image"
                     class="oe_avatar"
-                    options="{'preview_image': 'image_medium', 'zoom': true}"
+                    options="{'preview_image': 'image_1024', 'zoom': true}"
                 />
             </div>
             <xpath expr="//sheet" position="inside">

--- a/fs_product_multi_image/views/product_product.xml
+++ b/fs_product_multi_image/views/product_product.xml
@@ -10,7 +10,7 @@
             <xpath expr="//div[hasclass('o_kanban_image')]/img" position="attributes">
                 <attribute
                     name="t-att-src"
-                >kanban_image('product.product', 'image_medium', record.id.raw_value)</attribute>
+                >kanban_image('product.product', 'image_128', record.id.raw_value)</attribute>
             </xpath>
         </field>
     </record>
@@ -25,7 +25,7 @@
                 <field
                     name="image"
                     class="oe_avatar"
-                    options="{'preview_image': 'image_medium', 'zoom': true}"
+                    options="{'preview_image': 'image_128', 'zoom': true}"
                 />
             </field>
             <page name="sales" position="after">
@@ -49,7 +49,7 @@
                 <field
                     name="image"
                     class="oe_avatar"
-                    options="{'preview_image': 'image_medium', 'zoom': true}"
+                    options="{'preview_image': 'image_128', 'zoom': true}"
                 />
             </field>
         </field>

--- a/fs_product_multi_image/views/product_template.xml
+++ b/fs_product_multi_image/views/product_template.xml
@@ -15,7 +15,7 @@
                     name="image"
                     string="Image"
                     class="oe_avatar"
-                    options="{'preview_image': 'image_medium', 'zoom': true}"
+                    options="{'preview_image': 'image_128', 'zoom': true}"
                 />
             </field>
             <page name="sales" position="after">
@@ -46,7 +46,7 @@
             <xpath expr="//div[hasclass('o_kanban_image')]/img" position="attributes">
                 <attribute
                     name="t-att-src"
-                >kanban_image('product.template', 'image_medium', record.id.raw_value)</attribute>
+                >kanban_image('product.template', 'image_128', record.id.raw_value)</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
By default odoo defines into its own 'image.mixin' model, computed images in 1024, 512, 256 and 128 pixels from original images. Align our specific mixin to follow the same convention