### PR TITLE
[16.0][FIX] image_tag_environment: remove auto_install

### DIFF
--- a/image_tag_environment/__manifest__.py
+++ b/image_tag_environment/__manifest__.py
@@ -12,5 +12,4 @@
     "data": [
         "views/image_tag.xml",
     ],
-    "auto_install": True,
 }


### PR DESCRIPTION
Hello @simahawk , following the discussion here:
https://github.com/OCA/storage/pull/654#discussion_r3879679007

I open this PR because it was merged already.
Thanks to merge it